### PR TITLE
Add GE Flipper plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperConfig.java
@@ -1,0 +1,16 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("GeFlipper")
+public interface GeFlipperConfig extends Config {
+    @ConfigItem(
+            keyName = "items",
+            name = "Items to Flip",
+            description = "Comma separated list of items to flip. Leave empty to use all F2P items",
+            position = 0
+    )
+    default String items() { return ""; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperOverlay.java
@@ -1,0 +1,47 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class GeFlipperOverlay extends OverlayPanel {
+    @Inject
+    GeFlipperOverlay(GeFlipperPlugin plugin) {
+        super(plugin);
+        setPosition(OverlayPosition.TOP_LEFT);
+        setLayer(OverlayLayer.ABOVE_SCENE);
+        setPriority(OverlayPriority.HIGH);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.setPreferredSize(new Dimension(200, 300));
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("GE Flipper " + GeFlipperScript.VERSION)
+                .color(Color.GREEN)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left(Microbot.status)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Profit: " + GeFlipperScript.profit + " gp")
+                .build());
+        long elapsed = System.currentTimeMillis() - GeFlipperScript.startTime;
+        double hours = elapsed / 3600000.0;
+        double perHour = hours <= 0 ? 0 : GeFlipperScript.profit / hours;
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left(String.format("Profit p/h: %.0f", perHour))
+                .build());
+
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperPlugin.java
@@ -1,0 +1,50 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Mocrosoft + "GE Flipper",
+        description = "Flips items on the Grand Exchange",
+        tags = {"ge", "flip", "microbot"},
+        enabledByDefault = false
+)
+@Slf4j
+public class GeFlipperPlugin extends Plugin {
+    @Inject
+    private GeFlipperConfig config;
+
+    @Provides
+    GeFlipperConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(GeFlipperConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private GeFlipperOverlay overlay;
+    @Inject
+    private GeFlipperScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(overlay);
+        }
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperScript.java
@@ -6,6 +6,7 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.globval.VarbitIndices;
 import net.runelite.client.game.ItemManager;
 import net.runelite.http.api.item.ItemPrice;
 
@@ -72,12 +73,12 @@ public class GeFlipperScript extends Script {
                 }
                 Microbot.status = "Flipping " + item;
                 if (Rs2GrandExchange.buyItemAbove5Percent(item, 1)) {
-                    int buyPrice = Rs2GrandExchange.getOfferPrice();
+                    int buyPrice = Microbot.getVarbitValue(VarbitIndices.GE_OFFER_PRICE_PER_ITEM);
                     sleepUntil(Rs2GrandExchange::hasFinishedBuyingOffers);
                     Rs2GrandExchange.collectToInventory();
                     if (Rs2Inventory.hasItem(item)) {
                         if (Rs2GrandExchange.sellItemUnder5Percent(item)) {
-                            int sellPrice = Rs2GrandExchange.getOfferPrice();
+                            int sellPrice = Microbot.getVarbitValue(VarbitIndices.GE_OFFER_PRICE_PER_ITEM);
                             sleepUntil(Rs2GrandExchange::hasFinishedSellingOffers);
                             Rs2GrandExchange.collectToInventory();
                             profit += sellPrice - buyPrice;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperScript.java
@@ -1,0 +1,104 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.api.ItemComposition;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.game.ItemManager;
+import net.runelite.http.api.item.ItemPrice;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class GeFlipperScript extends Script {
+    public static final String VERSION = "1.0";
+    public static int profit = 0;
+    public static long startTime = 0;
+
+    private List<String> items = new ArrayList<>();
+    private int index = 0;
+
+    private void loadItems(GeFlipperConfig config) {
+        if (!config.items().trim().isEmpty()) {
+            items = Arrays.stream(config.items().split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toList());
+            return;
+        }
+        items = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+            Set<String> names = new TreeSet<>();
+            ItemManager itemManager = Microbot.getItemManager();
+            for (Field f : ItemID.class.getFields()) {
+                if (f.getType() != int.class || !Modifier.isStatic(f.getModifiers())) continue;
+                try {
+                    int id = (int) f.get(null);
+                    ItemComposition comp = itemManager.getItemComposition(id);
+                    if (comp != null && comp.isTradeable() && !comp.isMembers() && !comp.getName().equalsIgnoreCase("null")) {
+                        names.add(comp.getName());
+                    }
+                } catch (IllegalAccessException ignored) {}
+            }
+            return new ArrayList<>(names);
+        }).orElse(new ArrayList<>());
+    }
+
+    private int getItemId(String name) {
+        List<ItemPrice> list = Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getItemManager().search(name)).orElse(Collections.emptyList());
+        if (list.isEmpty()) return -1;
+        return list.get(0).getId();
+    }
+
+    public boolean run(GeFlipperConfig config) {
+        loadItems(config);
+        startTime = System.currentTimeMillis();
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) return;
+                if (!super.run() || !isRunning()) return;
+                if (index >= items.size()) {
+                    Microbot.status = "Finished";
+                    return;
+                }
+                String item = items.get(index);
+                if (!Rs2GrandExchange.isOpen()) {
+                    Rs2GrandExchange.openExchange();
+                    return;
+                }
+                Microbot.status = "Flipping " + item;
+                if (Rs2GrandExchange.buyItemAbove5Percent(item, 1)) {
+                    int buyPrice = Rs2GrandExchange.getOfferPrice();
+                    sleepUntil(Rs2GrandExchange::hasFinishedBuyingOffers);
+                    Rs2GrandExchange.collectToInventory();
+                    if (Rs2Inventory.hasItem(item)) {
+                        if (Rs2GrandExchange.sellItemUnder5Percent(item)) {
+                            int sellPrice = Rs2GrandExchange.getOfferPrice();
+                            sleepUntil(Rs2GrandExchange::hasFinishedSellingOffers);
+                            Rs2GrandExchange.collectToInventory();
+                            profit += sellPrice - buyPrice;
+                        }
+                    }
+                    Rs2GrandExchange.backToOverview();
+                }
+                index++;
+            } catch (Exception ex) {
+                Microbot.logStackTrace("GeFlipper", ex);
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        profit = 0;
+        startTime = 0;
+        items.clear();
+        index = 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add GE Flipper plugin with config, overlay, and script
- overlay shows script status and profit per hour
- plugin automatically gathers all F2P items and buys/sells to check margins

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850165c5ff88330804505bec638da8a