### PR TITLE
Add margin adjustments in GE flipper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperConfig.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("geflipper")
+public interface GeFlipperConfig extends Config {
+    String CONFIG_GROUP = "geflipper";
+
+    @ConfigItem(
+            keyName = "delay",
+            name = "Delay between items (ms)",
+            description = "Delay in milliseconds before flipping the next item",
+            position = 0
+    )
+    default int delay() { return 3000; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperOverlay.java
@@ -1,0 +1,60 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.misc.TimeUtils;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.time.Instant;
+
+public class GeFlipperOverlay extends OverlayPanel {
+    private final GeFlipperPlugin plugin;
+
+    @Inject
+    GeFlipperOverlay(GeFlipperPlugin plugin) {
+        super(plugin);
+        this.plugin = plugin;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("GE Flipper")
+                    .color(Color.GREEN)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder().build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Status:")
+                    .right(Microbot.status)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit:")
+                    .right(Integer.toString(plugin.getProfit()))
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit p/h:")
+                    .right(Integer.toString(plugin.getProfitPerHour()))
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Run time:")
+                    .right(TimeUtils.getFormattedDurationBetween(plugin.getStartTime(), Instant.now()))
+                    .build());
+        } catch (Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperPlugin.java
@@ -1,0 +1,73 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import com.google.inject.Provides;
+import lombok.Getter;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.plugins.microbot.Microbot;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.time.Instant;
+import net.runelite.client.plugins.microbot.util.misc.TimeUtils;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "GE Flipper",
+        description = "Microbot GE flipping plugin",
+        tags = {"ge", "flipping", "microbot"},
+        enabledByDefault = false
+)
+public class GeFlipperPlugin extends Plugin {
+    @Inject
+    private GeFlipperConfig config;
+    @Provides
+    GeFlipperConfig provideConfig(ConfigManager configManager) { return configManager.getConfig(GeFlipperConfig.class); }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private GeFlipperOverlay overlay;
+    @Inject
+    private GeFlipperScript script;
+
+    @Getter
+    private int profit;
+    @Getter
+    private Instant startTime;
+
+    @Override
+    protected void startUp() throws AWTException {
+        Microbot.status = "Starting";
+        startTime = Instant.now();
+        if (overlayManager != null) {
+            overlayManager.add(overlay);
+        }
+        script.run(this, config);
+    }
+
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+        startTime = null;
+        profit = 0;
+        Microbot.status = "IDLE";
+    }
+
+    void addProfit(int gp) { profit += gp; }
+
+    int getProfitPerHour() {
+        if (startTime == null) return 0;
+        long seconds = TimeUtils.getDurationInSeconds(startTime, Instant.now());
+        if (seconds == 0) return 0;
+        return (int) (profit * 3600L / seconds);
+    }
+
+    @Subscribe
+    public void onGameTick(GameTick tick) {
+        script.onGameTick();
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperScript.java
@@ -1,0 +1,310 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.api.ItemID;
+import net.runelite.api.ItemComposition;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class GeFlipperScript extends Script {
+    // Price and volume data are retrieved from GE Tracker;
+    // the OSRS Wiki is not used for margins
+    private static final int MAX_TRADE_LIMIT = 50;
+    private static final int GE_SLOT_COUNT = 3;
+    private static final int MIN_VOLUME = 100;
+    private static final int MIN_PROFIT = 1;
+
+    private final Queue<Integer> items = new ArrayDeque<>();
+    private final java.util.List<Integer> f2pItems = new java.util.ArrayList<>();
+    private final java.util.Random random = new java.util.Random();
+    private final java.util.Set<Integer> marginChecked = new java.util.HashSet<>();
+
+    private GeFlipperPlugin plugin;
+    private GeFlipperConfig config;
+    private boolean running;
+
+    private static class ActiveOffer {
+        int itemId;
+        int buyPrice;
+        int sellPrice;
+        int quantity;
+        int slot;
+        boolean buying;
+        boolean marginCheck;
+    }
+
+    private long lastAction;
+    private final java.util.List<ActiveOffer> offers = new java.util.ArrayList<>();
+    private final Limits limits = new Limits();
+
+    private int getCoins() {
+        return Rs2Inventory.itemQuantity(ItemID.COINS_995);
+    }
+
+    private String getItemName(int itemId) {
+        ItemComposition item = Microbot.getClientThread()
+                .runOnClientThreadOptional(() -> Microbot.getItemManager().getItemComposition(itemId))
+                .orElse(null);
+        return item != null ? item.getName() : "";
+    }
+
+    private java.util.List<Integer> loadF2pItems() {
+        return Microbot.getClientThread().runOnClientThread(() -> {
+            java.util.List<Integer> list = new java.util.ArrayList<>();
+            for (java.lang.reflect.Field f : ItemID.class.getFields()) {
+                if (!java.lang.reflect.Modifier.isStatic(f.getModifiers()) || f.getType() != int.class)
+                    continue;
+                try {
+                    int id = f.getInt(null);
+                    ItemComposition comp = Microbot.getItemManager().getItemComposition(id);
+                    if (comp != null && !comp.isMembers() && comp.isTradeable()) {
+                        list.add(id);
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+            java.util.Collections.shuffle(list, random);
+            return list;
+        });
+    }
+
+    private int pollRandomItem() {
+        if (items.isEmpty()) {
+            items.addAll(f2pItems);
+        }
+        int index = random.nextInt(items.size());
+        java.util.Iterator<Integer> it = items.iterator();
+        for (int i = 0; i < index; i++) it.next();
+        int val = it.next();
+        it.remove();
+        return val;
+    }
+
+    public boolean run(GeFlipperPlugin plugin, GeFlipperConfig config) {
+        if (running) {
+            return false;
+        }
+        this.plugin = plugin;
+        this.config = config;
+        running = true;
+        Microbot.enableAutoRunOn = false;
+
+        f2pItems.clear();
+        f2pItems.addAll(loadF2pItems());
+        items.clear();
+        items.addAll(f2pItems);
+        marginChecked.clear();
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) {
+                    Microbot.status = "Not logged in";
+                    return;
+                }
+                if (!super.run()) {
+                    Microbot.status = "Paused";
+                    return;
+                }
+
+                if (!Rs2GrandExchange.isOpen()) {
+                    Microbot.status = "Opening GE";
+                    Rs2GrandExchange.openExchange();
+                    return;
+                }
+
+                processOffers();
+
+                if (offers.size() >= GE_SLOT_COUNT) {
+                    Microbot.status = "Waiting for slot";
+                    return;
+                }
+
+                if (System.currentTimeMillis() - lastAction < config.delay()) {
+                    Microbot.status = "Delaying";
+                    return;
+                }
+
+                if (items.isEmpty()) {
+                    Microbot.status = "Loading items";
+                    if (f2pItems.isEmpty()) {
+                        f2pItems.addAll(loadF2pItems());
+                    }
+                    items.addAll(f2pItems);
+                    if (items.isEmpty()) {
+                        Microbot.status = "Queue empty";
+                        return;
+                    }
+                }
+
+                int next = pollRandomItem();
+                ActiveOffer offer = prepareItem(next);
+                if (offer == null) {
+                    items.offer(next);
+                    java.util.List<Integer> tmp = new java.util.ArrayList<>(items);
+                    java.util.Collections.shuffle(tmp, random);
+                    items.clear();
+                    items.addAll(tmp);
+                    lastAction = System.currentTimeMillis();
+                    return;
+                }
+
+                var slotInfo = Rs2GrandExchange.getAvailableSlot();
+                if (slotInfo.getLeft() == null || slotInfo.getLeft().ordinal() >= GE_SLOT_COUNT) {
+                    items.offer(next);
+                    java.util.List<Integer> tmp = new java.util.ArrayList<>(items);
+                    java.util.Collections.shuffle(tmp, random);
+                    items.clear();
+                    items.addAll(tmp);
+                    return;
+                }
+
+                String itemName = getItemName(next);
+                Microbot.status = "Buying " + itemName;
+                Rs2GrandExchange.buyItem(itemName, offer.buyPrice, offer.quantity);
+                offer.slot = slotInfo.getLeft().ordinal();
+                offer.buying = true;
+                offers.add(offer);
+                lastAction = System.currentTimeMillis();
+            } catch (Exception ex) {
+                log.error("Error in GE flipper", ex);
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private ActiveOffer prepareItem(int itemId) {
+        String itemName = getItemName(itemId);
+        if (itemName == null || itemName.isEmpty()) return null;
+        try {
+            int highVol = Rs2GrandExchange.getSellingVolume(itemId);
+            int lowVol = Rs2GrandExchange.getBuyingVolume(itemId);
+
+            int high = Rs2GrandExchange.getSellPrice(itemId);
+            int low = Rs2GrandExchange.getOfferPrice(itemId);
+            int sellPrice = (int) Math.ceil(high * 1.05); // sell for +5%
+            int buyPrice = (int) Math.floor(low * 0.95); // buy for -5%
+
+            Integer limit = limits.fetchLimit(itemId);
+            if (high == 0 || low == 0) {
+                Microbot.log(itemName + " price lookup failed, skipping");
+                Microbot.status = "No price";
+                return null;
+            }
+            if (sellPrice - buyPrice < MIN_PROFIT) {
+                Microbot.log(itemName + " margin below " + MIN_PROFIT + "gp, skipping");
+                Microbot.status = "Bad margin";
+                return null;
+            }
+            if (highVol < MIN_VOLUME || lowVol < MIN_VOLUME) {
+                Microbot.log(itemName + " volume too low, skipping");
+                Microbot.status = "Low volume";
+                return null;
+            }
+            if (limit == null || limit <= 0) {
+                Microbot.log(itemName + " limit fetch failed");
+                Microbot.status = "No limit";
+                return null;
+            }
+            int remaining = limits.getRemaining(itemId, limit);
+            if (remaining <= 0) {
+                Microbot.log(itemName + " reached trade limit, waiting");
+                Microbot.status = "Limit reached";
+                return null;
+            }
+
+            int coins = getCoins();
+            int quantity;
+            ActiveOffer offer = new ActiveOffer();
+            offer.itemId = itemId;
+            if (!marginChecked.contains(itemId)) {
+                offer.buyPrice = (int) Math.ceil(high * 1.05); // check margin +5%
+                offer.sellPrice = (int) Math.floor(low * 0.95); // sell quickly -5%
+                if (coins < offer.buyPrice) {
+                    Microbot.log("Not enough gp to buy " + itemName);
+                    Microbot.status = "Insufficient gp";
+                    return null;
+                }
+                quantity = 1;
+                offer.marginCheck = true;
+            } else {
+                quantity = Math.min(Math.min(Math.min(limit, MAX_TRADE_LIMIT), remaining), coins / buyPrice);
+                if (quantity <= 0) {
+                    Microbot.log("Not enough gp to buy " + itemName);
+                    Microbot.status = "Insufficient gp";
+                    return null;
+                }
+                offer.buyPrice = buyPrice;
+                offer.sellPrice = sellPrice;
+                offer.marginCheck = false;
+            }
+            offer.quantity = quantity;
+            return offer;
+        } catch (Exception ex) {
+            log.error("Failed to fetch info for {}", itemName, ex);
+            return null;
+        }
+    }
+
+    private void processOffers() {
+        var geOffers = Microbot.getClient().getGrandExchangeOffers();
+        java.util.Iterator<ActiveOffer> it = offers.iterator();
+        while (it.hasNext()) {
+            ActiveOffer offer = it.next();
+            if (offer.slot >= geOffers.length) {
+                it.remove();
+                continue;
+            }
+            var geOffer = geOffers[offer.slot];
+            if (geOffer == null) {
+                continue;
+            }
+            if (offer.buying) {
+                if (geOffer.getState() == net.runelite.api.GrandExchangeOfferState.BOUGHT) {
+                    Rs2GrandExchange.collect(false);
+                    offer.buying = false;
+                    String name = getItemName(offer.itemId);
+                    Microbot.status = "Selling " + name;
+                    Rs2GrandExchange.sellItem(name, offer.quantity, offer.sellPrice);
+                }
+            } else {
+                if (geOffer.getState() == net.runelite.api.GrandExchangeOfferState.SOLD) {
+                    Rs2GrandExchange.collectToBank();
+                    if (!offer.marginCheck) {
+                        plugin.addProfit((offer.sellPrice - offer.buyPrice) * offer.quantity);
+                    }
+                    limits.reduceRemaining(offer.itemId, offer.quantity);
+                    items.offer(offer.itemId);
+                    marginChecked.add(offer.itemId);
+                    java.util.List<Integer> tmp = new java.util.ArrayList<>(items);
+                    java.util.Collections.shuffle(tmp, random);
+                    items.clear();
+                    items.addAll(tmp);
+                    it.remove();
+                    lastAction = System.currentTimeMillis();
+                }
+            }
+        }
+    }
+
+    public void onGameTick() {
+        // not used
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        running = false;
+        offers.clear();
+        items.clear();
+        limits.clear();
+        marginChecked.clear();
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/Limits.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/Limits.java
@@ -1,0 +1,93 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class Limits {
+    // Trade limits fetched from GE Tracker; no OSRS Wiki calls
+    private static final String LIMIT_API = "https://www.ge-tracker.com/api/items/";
+    private static final String USER_AGENT = "Microbot GE Flipper";
+    private static final long FOUR_HOURS_MS = TimeUnit.HOURS.toMillis(4);
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
+
+    private final Map<Integer, Integer> remainingLimits = new HashMap<>();
+    private final Map<Integer, Long> resetTimes = new HashMap<>();
+
+    private JsonObject parseJson(String json) {
+        JsonReader reader = new JsonReader(new StringReader(json));
+        reader.setLenient(true);
+        try {
+            var element = new JsonParser().parse(reader);
+            if (!element.isJsonObject()) {
+                log.error("Response was not JSON: {}", json.length() > 100 ? json.substring(0, 100) : json);
+                return null;
+            }
+            return element.getAsJsonObject();
+        } catch (Exception ex) {
+            log.error("Failed to parse JSON", ex);
+            return null;
+        }
+    }
+
+    public Integer fetchLimit(int itemId) {
+        try {
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(URI.create(LIMIT_API + itemId))
+                    .header("User-Agent", USER_AGENT)
+                    .build();
+            HttpResponse<String> resp = HTTP_CLIENT.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200) {
+                log.info("Limit fetch failed: {}", resp.statusCode());
+                return null;
+            }
+            JsonObject obj = parseJson(resp.body());
+            if (obj == null || !obj.has("data")) {
+                return null;
+            }
+            JsonObject data = obj.getAsJsonObject("data");
+            if (data.has("limit") && !data.get("limit").isJsonNull()) {
+                return data.get("limit").getAsInt();
+            }
+        } catch (Exception ex) {
+            log.error("Failed to fetch limit for {}", itemId, ex);
+        }
+        return null;
+    }
+
+    public int getRemaining(int itemId, int limit) {
+        long now = System.currentTimeMillis();
+        long reset = resetTimes.getOrDefault(itemId, 0L);
+        if (now >= reset) {
+            remainingLimits.put(itemId, limit);
+            resetTimes.put(itemId, now + FOUR_HOURS_MS);
+        }
+        return remainingLimits.getOrDefault(itemId, limit);
+    }
+
+    public void reduceRemaining(int itemId, int qty) {
+        remainingLimits.compute(itemId, (k, v) -> {
+            if (v == null) return 0;
+            int newVal = v - qty;
+            return Math.max(newVal, 0);
+        });
+    }
+
+    public void clear() {
+        remainingLimits.clear();
+        resetTimes.clear();
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
@@ -105,7 +105,7 @@ public class Rs2GrandExchange {
             if (npc == null) return false;
             Rs2Npc.interact(npc, "exchange");
             sleepUntil(Rs2GrandExchange::isOpen, 5000);
-            return false;
+            return isOpen();
         } catch (Exception ex) {
             Microbot.logStackTrace("Rs2GrandExchange", ex);
         }


### PR DESCRIPTION
## Summary
- adjust buy offers to -5% and sell offers to +5%
- use new prices when validating margins and calculating quantity
- perform a one-item margin check at +5%/-5% before flipping
- clarify in comments that prices and limits use GE Tracker, not OSRS Wiki

## Testing
- `javac -version`
- `javac runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/*.java` *(fails: missing project dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6850a33280fc8330a16f7ea996dd3a62