### PR TITLE
Add GE Flipper plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
@@ -1,0 +1,24 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("geflipper")
+public interface GEFlipperConfig extends Config {
+    @ConfigItem(
+            keyName = "minVolume",
+            name = "Minimum Volume",
+            description = "Skip items with volume below this",
+            position = 1
+    )
+    default int minVolume() { return 500; }
+
+    @ConfigItem(
+            keyName = "minMargin",
+            name = "Minimum Margin",
+            description = "Minimum gp margin to flip",
+            position = 2
+    )
+    default int minMargin() { return 10; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
@@ -1,0 +1,44 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class GEFlipperOverlay extends OverlayPanel {
+    @Inject
+    GEFlipperOverlay(GEFlipperPlugin plugin) {
+        super(plugin);
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("Micro GE Flipper")
+                    .color(Color.GREEN)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder().build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Status: " + GEFlipperScript.status)
+                    .build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit: " + GEFlipperScript.profit + " gp")
+                    .build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit p/h: " + GEFlipperScript.getProfitPerHour())
+                    .build());
+        } catch (Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "GE Flipper",
+        description = "Simple GE flipping bot",
+        tags = {"grand exchange", "flip", "ge"},
+        enabledByDefault = false
+)
+@Slf4j
+public class GEFlipperPlugin extends Plugin {
+    @Inject
+    private GEFlipperConfig config;
+    @Provides
+    GEFlipperConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(GEFlipperConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private GEFlipperOverlay overlay;
+
+    @Inject
+    GEFlipperScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(overlay);
+        }
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
@@ -1,0 +1,79 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.api.GameState;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.item.Rs2ItemManager;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class GEFlipperScript extends Script {
+    public static String status = "Idle";
+    public static int profit = 0;
+    private long startTime;
+    private final Rs2ItemManager itemManager = new Rs2ItemManager();
+
+    private static final List<String> F2P_ITEMS = Arrays.asList(
+            "Lobster", "Rune scimitar", "Rune 2h sword", "Maple logs",
+            "Adamant arrow", "Mithril ore", "Rune sword", "Steel platebody"
+    );
+
+    public boolean run(GEFlipperConfig config) {
+        Rs2AntibanSettings.naturalMouse = true;
+        startTime = System.currentTimeMillis();
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            if (!Microbot.isLoggedIn() || Microbot.getClient().getGameState() != GameState.LOGGED_IN)
+                return;
+            if (!super.run())
+                return;
+            try {
+                if (!Rs2GrandExchange.isOpen()) {
+                    status = "Opening GE";
+                    Rs2GrandExchange.openExchange();
+                    return;
+                }
+                int gp = Rs2Inventory.count("Coins");
+                for (String itemName : F2P_ITEMS) {
+                    int itemId = itemManager.getItemId(itemName);
+                    int buyPrice = Rs2GrandExchange.getOfferPrice(itemId);
+                    int sellPrice = Rs2GrandExchange.getSellPrice(itemId);
+                    int volume = Rs2GrandExchange.getSellingQuantity(itemId);
+                    int margin = sellPrice - buyPrice;
+                    if (margin < config.minMargin() || volume < config.minVolume())
+                        continue;
+                    int quantity = Math.min(gp / buyPrice, 100); // simple calc
+                    if (quantity <= 0)
+                        continue;
+                    status = "Buying " + itemName;
+                    if (Rs2GrandExchange.buyItem(itemName, buyPrice, quantity)) {
+                        profit += margin * quantity;
+                        break;
+                    }
+                }
+            } catch (Exception ex) {
+                System.out.println(ex.getMessage());
+            }
+        }, 0, 3000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    public static String getProfitPerHour() {
+        long timeRan = System.currentTimeMillis() - Microbot.getScriptTimer();
+        if (timeRan <= 0) {
+            return "0";
+        }
+        double ph = profit * 3600000d / timeRan;
+        return String.format("%,.0f", ph);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        Rs2AntibanSettings.naturalMouse = false;
+    }
+}


### PR DESCRIPTION
## Summary
- add new GE Flipper plugin
- include overlay with status and profit metrics
- use natural mouse antiban and simple F2P item list

## Testing
- `mvn` not available, build skipped

------
https://chatgpt.com/codex/tasks/task_e_6851ecb39dc48330adfe161556b68d2b