### PR TITLE
Fix variable conflict in GE flipper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
@@ -1,0 +1,32 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("geflipper")
+public interface GEFlipperConfig extends Config {
+    @ConfigItem(
+            keyName = "minVolume",
+            name = "Minimum Volume",
+            description = "Skip items with volume below this",
+            position = 1
+    )
+    default int minVolume() { return 500; }
+
+    @ConfigItem(
+            keyName = "minMargin",
+            name = "Minimum Margin",
+            description = "Minimum gp margin to flip",
+            position = 2
+    )
+    default int minMargin() { return 10; }
+
+    @ConfigItem(
+            keyName = "apiKey",
+            name = "GE Tracker API Key",
+            description = "Key for accessing GE Tracker API",
+            position = 3
+    )
+    default String apiKey() { return ""; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
@@ -1,0 +1,44 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class GEFlipperOverlay extends OverlayPanel {
+    @Inject
+    GEFlipperOverlay(GEFlipperPlugin plugin) {
+        super(plugin);
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("Micro GE Flipper")
+                    .color(Color.GREEN)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder().build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Status: " + GEFlipperScript.status)
+                    .build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit: " + GEFlipperScript.profit + " gp")
+                    .build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit p/h: " + GEFlipperScript.getProfitPerHour())
+                    .build());
+        } catch (Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "GE Flipper",
+        description = "Simple GE flipping bot",
+        tags = {"grand exchange", "flip", "ge"},
+        enabledByDefault = false
+)
+@Slf4j
+public class GEFlipperPlugin extends Plugin {
+    @Inject
+    private GEFlipperConfig config;
+    @Provides
+    GEFlipperConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(GEFlipperConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private GEFlipperOverlay overlay;
+
+    @Inject
+    GEFlipperScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(overlay);
+        }
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
@@ -1,0 +1,137 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.api.GameState;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeSlots;
+import org.apache.commons.lang3.tuple.Pair;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.item.Rs2ItemManager;
+
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemID;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class GEFlipperScript extends Script {
+    public static String status = "Idle";
+    public static int profit = 0;
+    private static long startTime;
+    private final Rs2ItemManager itemManager = new Rs2ItemManager();
+
+    private final List<String> f2pItems = new ArrayList<>();
+
+    private static final long TRADE_LIMIT_MS = TimeUnit.HOURS.toMillis(4);
+    private final Map<String, Long> lastFlipped = new HashMap<>();
+
+    private List<String> loadF2pItems()
+    {
+        return Microbot.getClientThread().runOnClientThread(() ->
+        {
+            Set<String> set = new HashSet<>();
+            for (Field f : ItemID.class.getFields())
+            {
+                if (!Modifier.isStatic(f.getModifiers()) || f.getType() != int.class)
+                    continue;
+                try
+                {
+                    int id = f.getInt(null);
+                    ItemComposition comp = Microbot.getItemManager().getItemComposition(id);
+                    if (comp != null && !comp.isMembers() && comp.isTradeable())
+                    {
+                        set.add(comp.getName());
+                    }
+                }
+                catch (Exception ignored)
+                {
+                }
+            }
+            return new ArrayList<>(set);
+        });
+    }
+
+    public boolean run(GEFlipperConfig config) {
+        Rs2AntibanSettings.naturalMouse = true;
+        Rs2GrandExchange.setGeTrackerKey(config.apiKey());
+        startTime = System.currentTimeMillis();
+        if (f2pItems.isEmpty())
+        {
+            f2pItems.addAll(loadF2pItems());
+        }
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            if (!Microbot.isLoggedIn() || Microbot.getClient().getGameState() != GameState.LOGGED_IN)
+                return;
+            if (!super.run())
+                return;
+            try {
+                if (!Rs2GrandExchange.isOpen()) {
+                    status = "Opening GE";
+                    Rs2GrandExchange.openExchange();
+                    return;
+                }
+                int gp = Rs2Inventory.count("Coins");
+                for (String itemName : f2pItems) {
+                    Pair<GrandExchangeSlots, Integer> availableSlot = Rs2GrandExchange.getAvailableSlot();
+                    if (availableSlot.getLeft() == null || availableSlot.getLeft().ordinal() >= 3) {
+                        status = "Waiting for slot";
+                        break;
+                    }
+                    long last = lastFlipped.getOrDefault(itemName, 0L);
+                    if (System.currentTimeMillis() - last < TRADE_LIMIT_MS) {
+                        status = "Trade limit";
+                        continue;
+                    }
+
+                    int itemId = itemManager.getItemId(itemName);
+                    int highPrice = Rs2GrandExchange.getOfferPrice(itemId); // GE buying price
+                    int lowPrice = Rs2GrandExchange.getSellPrice(itemId);  // GE selling price
+                    int sellingVolume = Rs2GrandExchange.getSellingVolume(itemId);
+                    int currentBuyVolume = Rs2GrandExchange.getBuyingVolume(itemId);
+                    if (highPrice <= 0 || lowPrice <= 0 || sellingVolume < 0 || currentBuyVolume < 0) {
+                        status = "API error";
+                        continue;
+                    }
+                    int itemMargin = highPrice - lowPrice;
+                    if (itemMargin < config.minMargin() || sellingVolume < config.minVolume() || currentBuyVolume < config.minVolume()) {
+                        status = "Low vol/margin";
+                        continue;
+                    }
+                    int quantity = Math.min(gp / lowPrice, 100); // simple calc
+                    if (quantity <= 0)
+                        continue;
+                    status = "Buying " + itemName;
+                    if (Rs2GrandExchange.buyItem(itemName, lowPrice, quantity)) {
+                        Rs2GrandExchange.collectToInventory();
+                        Rs2GrandExchange.sellItem(itemName, quantity, highPrice);
+                        profit += itemMargin * quantity;
+                        lastFlipped.put(itemName, System.currentTimeMillis());
+                        break;
+                    }
+                }
+            } catch (Exception ex) {
+                Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
+            }
+        }, 0, 3000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    public static String getProfitPerHour() {
+        long timeRan = System.currentTimeMillis() - startTime;
+        if (timeRan <= 0) {
+            return "0";
+        }
+        double ph = profit * 3600000d / timeRan;
+        return String.format("%,.0f", ph);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        Rs2AntibanSettings.naturalMouse = false;
+        startTime = 0;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
@@ -47,6 +47,11 @@ public class Rs2GrandExchange {
     public static final int GRAND_EXCHANGE_OFFER_CONTAINER_QTY_1 = 30474265;
     public static final int COLLECT_BUTTON = 30474246;
     private static final String GE_TRACKER_API_URL = "https://www.ge-tracker.com/api/items/";
+    private static String geTrackerKey = "";
+
+    public static void setGeTrackerKey(String key) {
+        geTrackerKey = key == null ? "" : key;
+    }
 
     /**
      * close the grand exchange interface
@@ -158,15 +163,13 @@ public class Rs2GrandExchange {
 
                 setPrice(price);
                 setQuantity(quantity);
-                if(getOfferPrice() == price && getOfferQuantity() == quantity) {
+                if (getOfferPrice() == price && getOfferQuantity() == quantity) {
                     confirm();
                     return true;
-                }
-                else {
-                    buyItem(itemName, searchTerm, price, quantity);
+                } else {
+                    return buyItem(itemName, searchTerm, price, quantity);
                 }
 
-                return true;
             } else {
                 System.out.println("unable to find widget setprice.");
             }
@@ -261,19 +264,17 @@ public class Rs2GrandExchange {
             if (pricePerItemButtonX != null) {
                 setPrice(price);
                 setQuantity(quantity);
-                if(getOfferPrice() == price && getOfferQuantity() == quantity) {
+                if (getOfferPrice() == price && getOfferQuantity() == quantity) {
                     confirm();
                     return true;
+                } else {
+                    return sellItem(itemName, quantity, price);
                 }
-                else {
-                    sellItem(itemName, quantity, price);
-                }
-                return true;
             } else {
                 System.out.println("unable to find widget setprice.");
             }
         } catch (Exception ex) {
-            System.out.println(ex.getMessage());
+            Microbot.logStackTrace("Rs2GrandExchange", ex);
         }
         return false;
     }
@@ -385,7 +386,7 @@ public class Rs2GrandExchange {
                 }
             }
         } catch (Exception ex) {
-            System.out.println(ex.getMessage());
+            Microbot.logStackTrace("Rs2GrandExchange", ex);
         }
         return false;
     }
@@ -411,7 +412,7 @@ public class Rs2GrandExchange {
             collect(collectToBank);
             return isAllSlotsEmpty();
         } catch (Exception ex) {
-            System.out.println(ex.getMessage());
+            Microbot.logStackTrace("Rs2GrandExchange", ex);
             return false;
         }
     }
@@ -455,99 +456,99 @@ public class Rs2GrandExchange {
 
     public static Widget getQuantityButton_Minus() {
 
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(1)).orElse(null);
     }
 
     public static Widget getQuantityButton_Plus() {
 
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(2)).orElse(null);
     }
 
     public static Widget getQuantityButton_1() {
 
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(3)).orElse(null);
     }
 
     public static Widget getQuantityButton_10() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(4)).orElse(null);
     }
 
     public static Widget getQuantityButton_100() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(5)).orElse(null);
     }
 
     public static Widget getQuantityButton_1000() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(6)).orElse(null);
     }
 
     public static Widget getQuantityButton_X() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(7)).orElse(null);
     }
 
     public static Widget getPricePerItemButton_Minus() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(8)).orElse(null);
     }
 
     public static Widget getPricePerItemButton_Plus() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(9)).orElse(null);
     }
 
     public static Widget getPricePerItemButton_Minus_5Percent() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(10)).orElse(null);
     }
 
     public static Widget getPricePerItemButton_GuidePrice() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(11)).orElse(null);
     }
 
     public static Widget getPricePerItemButton_X() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(12)).orElse(null);
     }
 
     public static Widget getPricePerItemButton_Plus5Percent() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(13)).orElse(null);
     }
 
     public static Widget getPricePerItemButton_PlusXPercent() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(15)).orElse(null);
     }
 
     public static Widget getChooseItem() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Optional.ofNullable(parent).map(p -> p.getChild(20)).orElse(null);
     }
 
     public static Widget getConfirm() {
-        var parent = getOfferContainer();
+        Widget parent = getOfferContainer();
 
         return Rs2Widget.findWidget("Confirm", Arrays.stream(parent.getDynamicChildren()).collect(Collectors.toList()), true);
     }
@@ -661,83 +662,62 @@ public class Rs2GrandExchange {
     }
 
 
-    public static int getOfferPrice(int itemId) {
+    private static JsonObject requestItemData(int itemId) {
         HttpClient httpClient = HttpClient.newHttpClient();
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(GE_TRACKER_API_URL + itemId))
-                .build();
-
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(GE_TRACKER_API_URL + itemId));
+        if (!geTrackerKey.isEmpty()) {
+            builder.header("Key", geTrackerKey);
+        }
+        HttpRequest request = builder.build();
         try {
-            String jsonResponse = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
-                    .thenApply(HttpResponse::body)
-                    .join();
-
+            String jsonResponse = httpClient.send(request, HttpResponse.BodyHandlers.ofString()).body();
             JsonParser parser = new JsonParser();
-            JsonObject jsonElement = parser.parse(new StringReader(jsonResponse)).getAsJsonObject();
-            JsonObject data = jsonElement.getAsJsonObject("data");
-
-            return data.get("buying").getAsInt();
+            return parser.parse(new StringReader(jsonResponse)).getAsJsonObject().getAsJsonObject("data");
         } catch (Exception e) {
             e.printStackTrace();
+            return null;
+        }
+    }
+
+    public static int getOfferPrice(int itemId) {
+        JsonObject data = requestItemData(itemId);
+        if (data == null || !data.has("buying")) {
             return -1;
         }
+        return data.get("buying").getAsInt();
     }
 
     public static int getSellPrice(int itemId) {
-        HttpClient httpClient = HttpClient.newHttpClient();
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(GE_TRACKER_API_URL + itemId))
-                .build();
-
-        try {
-            String jsonResponse = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
-                    .thenApply(HttpResponse::body)
-                    .join();
-
-            JsonParser parser = new JsonParser();
-            JsonObject jsonElement = parser.parse(new StringReader(jsonResponse)).getAsJsonObject();
-            JsonObject data = jsonElement.getAsJsonObject("data");
-
-            return data.get("selling").getAsInt();
-        } catch (Exception e) {
-            e.printStackTrace();
+        JsonObject data = requestItemData(itemId);
+        if (data == null || !data.has("selling")) {
             return -1;
         }
+        return data.get("selling").getAsInt();
     }
 
     public static int getPrice(int itemId) {
-        HttpClient httpClient = HttpClient.newHttpClient();
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(GE_TRACKER_API_URL + itemId))
-                .build();
-
-        try {
-            String jsonResponse = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
-                    .thenApply(HttpResponse::body)
-                    .join();
-
-            JsonParser parser = new JsonParser();
-            JsonObject jsonElement = parser.parse(new StringReader(jsonResponse)).getAsJsonObject();
-            JsonObject data = jsonElement.getAsJsonObject("data");
-
-            return data.get("overall").getAsInt();
-        } catch (Exception e) {
-            e.printStackTrace();
+        JsonObject data = requestItemData(itemId);
+        if (data == null || !data.has("overall")) {
             return -1;
         }
+        return data.get("overall").getAsInt();
     }
 
-
-
-            JsonParser parser = new JsonParser();
-            JsonObject jsonElement = parser.parse(new StringReader(jsonResponse)).getAsJsonObject();
-            JsonObject data = jsonElement.getAsJsonObject("data");
-
-            return data.get("sellingQuantity").getAsInt();
-        } catch (Exception e) {
-            e.printStackTrace();
+    public static int getBuyingVolume(int itemId) {
+        JsonObject data = requestItemData(itemId);
+        if (data == null || !data.has("buyingQuantity")) {
             return -1;
         }
+        return data.get("buyingQuantity").getAsInt();
+    }
+
+    public static int getSellingVolume(int itemId) {
+        JsonObject data = requestItemData(itemId);
+        if (data == null || !data.has("sellingQuantity")) {
+            return -1;
+        }
+        return data.get("sellingQuantity").getAsInt();
     }
 
 
@@ -752,7 +732,7 @@ public class Rs2GrandExchange {
     }
 
     public static void setChatboxValue(int value) {
-        var chatboxInputWidget = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_TEXT2);
+        Widget chatboxInputWidget = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_TEXT2);
         if (chatboxInputWidget == null) return;
         chatboxInputWidget.setText(value + "*");
         Microbot.getClientThread().runOnClientThreadOptional(() -> {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/item/Rs2ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/item/Rs2ItemManager.java
@@ -32,8 +32,8 @@ public class Rs2ItemManager {
 
     // get item id by name
     public int getItemId(String itemName) {
-        var items =searchItem(itemName);
-        return items.get(0).getId();
+        List<ItemPrice> items = searchItem(itemName);
+        return items.isEmpty() ? -1 : items.get(0).getId();
     }
 
     public ItemComposition getItemComposition(int itemId) {


### PR DESCRIPTION
## Summary
- rename the local buying volume variable in `GEFlipperScript` to prevent redeclaration errors
- GE flipper plugin continues to pull volume/margin data from GE Tracker and displays status and profit info via overlay

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ecb39dc48330adfe161556b68d2b