### PR TITLE
Add GE Flipper plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
@@ -1,0 +1,16 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("geflipper")
+public interface GEFlipperConfig extends Config {
+    @ConfigItem(
+            keyName = "minMargin",
+            name = "Minimum Margin",
+            description = "Only flip items with at least this margin",
+            position = 1
+    )
+    default int minMargin() { return 10; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
@@ -1,0 +1,51 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+import java.text.NumberFormat;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class GEFlipperOverlay extends OverlayPanel {
+    private final GEFlipperPlugin plugin;
+
+    @Inject
+    GEFlipperOverlay(GEFlipperPlugin plugin) {
+        super(plugin);
+        this.plugin = plugin;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.getChildren().clear();
+            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("GE Flipper " + GEFlipperScript.VERSION)
+                    .color(Color.CYAN)
+                    .build());
+
+            NumberFormat fmt = NumberFormat.getIntegerInstance();
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit:")
+                    .right(fmt.format(GEFlipperScript.profit))
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit p/h:")
+                    .right(fmt.format(GEFlipperScript.profitPerHour))
+                    .build());
+
+        } catch (Exception ex) {
+            Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
+        }
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "GE Flipper",
+        description = "Simple GE flipping plugin",
+        tags = {"ge", "flipping", "microbot"},
+        enabledByDefault = false
+)
+@Slf4j
+public class GEFlipperPlugin extends Plugin {
+    @Inject
+    private GEFlipperConfig config;
+
+    @Provides
+    GEFlipperConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(GEFlipperConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private GEFlipperOverlay overlay;
+    @Inject
+    private GEFlipperScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(overlay);
+        }
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
@@ -1,0 +1,147 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.item.Rs2ItemManager;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class GEFlipperScript extends Script {
+
+    public static final String VERSION = "1.0";
+    public static int profit = 0;
+    public static int profitPerHour = 0;
+
+    private static final int MAX_SLOTS = 3;
+
+    private static class Offer {
+        String name;
+        int buy;
+        int sell;
+    }
+
+    private final List<Offer> offers = new ArrayList<>();
+    private int startingGp;
+
+    private long startTime;
+    private final Rs2ItemManager itemManager = new Rs2ItemManager();
+    private GEFlipperConfig config;
+    private List<String> items = new ArrayList<>();
+    private int currentIndex = 0;
+
+    private enum State {BUY, WAIT_BUY, SELL, WAIT_SELL}
+    private State state = State.BUY;
+
+    public boolean run(GEFlipperConfig config) {
+        this.config = config;
+        final GEFlipperConfig conf = this.config;
+        items = getTradeableF2PItems();
+        currentIndex = 0;
+        startingGp = Rs2Inventory.itemQuantity(ItemID.COINS_995);
+        startTime = System.currentTimeMillis();
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) return;
+                if (!super.run()) return;
+
+                if (items.isEmpty()) return;
+
+                switch (state) {
+                    case BUY:
+                        if (offers.size() >= MAX_SLOTS) {
+                            state = State.WAIT_BUY;
+                            break;
+                        }
+                        String name = items.get(currentIndex);
+                        nextItem();
+                        int id = itemManager.getItemId(name);
+                        if (id <= 0) {
+                            break;
+                        }
+                        int buy = Rs2GrandExchange.getOfferPrice(id);
+                        int sell = Rs2GrandExchange.getSellPrice(id);
+                        int m = sell - buy;
+                        if (m < conf.minMargin()) {
+                            break;
+                        }
+                        if (Rs2Inventory.itemQuantity(ItemID.COINS_995) < buy) {
+                            break;
+                        }
+                        Rs2GrandExchange.buyItem(name, buy, 1);
+                        Offer offer = new Offer();
+                        offer.name = name;
+                        offer.buy = buy;
+                        offer.sell = sell;
+                        offers.add(offer);
+                        if (offers.size() >= MAX_SLOTS) {
+                            state = State.WAIT_BUY;
+                        }
+                        break;
+                    case WAIT_BUY:
+                        if (Rs2GrandExchange.hasFinishedBuyingOffers()) {
+                            Rs2GrandExchange.collect(false);
+                            state = State.SELL;
+                        }
+                        break;
+                    case SELL:
+                        for (Offer o : offers) {
+                            Rs2GrandExchange.sellItem(o.name, 1, o.sell);
+                        }
+                        state = State.WAIT_SELL;
+                        break;
+                    case WAIT_SELL:
+                        if (Rs2GrandExchange.hasFinishedSellingOffers()) {
+                            Rs2GrandExchange.collect(true);
+                            offers.clear();
+                            state = State.BUY;
+                        }
+                        break;
+                    default:
+                        break;
+                }
+
+                profit = Rs2Inventory.itemQuantity(ItemID.COINS_995) - startingGp;
+                long elapsed = System.currentTimeMillis() - startTime;
+                profitPerHour = (int) (profit / (elapsed / 3600000.0));
+
+            } catch (Exception ex) {
+                Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        profit = 0;
+        profitPerHour = 0;
+    }
+
+    private void nextItem() {
+        currentIndex++;
+        if (currentIndex >= items.size()) {
+            currentIndex = 0;
+        }
+    }
+
+    public List<String> getTradeableF2PItems() {
+        List<String> items = new ArrayList<>();
+        int count = Microbot.getClient().getItemCount();
+        for (int id = 0; id < count; id++) {
+            final int itemId = id;
+            ItemComposition comp = Microbot.getClientThread().runOnClientThreadOptional(() ->
+                    Microbot.getItemManager().getItemComposition(itemId)).orElse(null);
+            if (comp != null && comp.isTradeable() && !comp.isMembers()) {
+                items.add(comp.getName());
+            }
+        }
+        return items;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/item/Rs2ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/item/Rs2ItemManager.java
@@ -26,13 +26,17 @@ public class Rs2ItemManager {
         if (query == null || query.trim().isEmpty()) {
             return Collections.emptyList();
         }
-        String lowerQuery = query.toLowerCase();
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getItemManager().search(query)).orElse(Collections.emptyList());
+        return Microbot.getClientThread().runOnClientThreadOptional(
+                () -> Microbot.getItemManager().search(query)
+        ).orElse(Collections.emptyList());
     }
 
     // get item id by name
     public int getItemId(String itemName) {
-        var items =searchItem(itemName);
+        var items = searchItem(itemName);
+        if (items.isEmpty()) {
+            return -1;
+        }
         return items.get(0).getId();
     }
 


### PR DESCRIPTION
## Summary
- add Grand Exchange Flipper plugin with overlay and config
- overlay displays live profit and profit per hour
- collect all tradeable F2P items for flipping
- avoid errors when no items are found during item search
- avoid CPU freeze by buying one item per tick
- format overlay profit numbers with separators

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f162938dc8330a1d8ab3e6fc939e3