### PR TITLE
Allow selecting specific item for GE Flipper

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -470,6 +470,7 @@
 							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 							<includes>
 								<include>net/runelite/client/plugins/microbot/example/**</include>
+                        <include>net/runelite/client/plugins/microbot/geflipper/**</include>
 							</includes>
 							<finalName>example</finalName>
 							<archive>

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
@@ -1,0 +1,34 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("geflipper")
+public interface GEFlipperConfig extends Config {
+
+
+    @ConfigItem(
+            keyName = "minVolume",
+            name = "Minimum Volume",
+            description = "Skip items with daily volume below this value",
+            position = 0
+    )
+    default int minVolume() { return 1000; }
+
+    @ConfigItem(
+            keyName = "delay",
+            name = "Loop Delay (ms)",
+            description = "Delay between flip checks",
+            position = 1
+    )
+    default int delay() { return 1000; }
+
+    @ConfigItem(
+            keyName = "cancelMinutes",
+            name = "Cancel Offer Minutes",
+            description = "Cancel buy offers after this many minutes",
+            position = 2
+    )
+    default int cancelMinutes() { return 25; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
@@ -1,0 +1,68 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.client.util.QuantityFormatter;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class GEFlipperOverlay extends OverlayPanel {
+    private final GEFlipperPlugin plugin;
+
+    @Inject
+    GEFlipperOverlay(GEFlipperPlugin plugin) {
+        super(plugin);
+        this.plugin = plugin;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.getChildren().clear();
+            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("GE Flipper " + GEFlipperScript.VERSION)
+                    .color(Color.CYAN)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Status:")
+                    .right(GEFlipperScript.status)
+                    .build());
+
+            long runtime = System.currentTimeMillis() - GEFlipperScript.startTime;
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Time Running:")
+                    .right(formatDuration(runtime))
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit:")
+                    .right(QuantityFormatter.formatNumber(GEFlipperScript.profit) + " gp")
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Profit p/h:")
+                    .right(QuantityFormatter.formatNumber(GEFlipperScript.profitPerHour) + " gp")
+                    .build());
+
+        } catch (Exception ex) {
+            Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
+        }
+        return super.render(graphics);
+    }
+
+    private String formatDuration(long millis) {
+        long hours = TimeUnit.MILLISECONDS.toHours(millis);
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(millis) % 60;
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(millis) % 60;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.AWTException;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "GE Flipper",
+        description = "Simple GE flipping plugin",
+        tags = {"ge", "flipping", "microbot"},
+        enabledByDefault = false
+)
+@Slf4j
+public class GEFlipperPlugin extends Plugin {
+    @Inject
+    private GEFlipperConfig config;
+
+    @Provides
+    GEFlipperConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(GEFlipperConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private GEFlipperOverlay overlay;
+    @Inject
+    private GEFlipperScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(overlay);
+        }
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
@@ -1,0 +1,301 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.item.Rs2ItemManager;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+public class GEFlipperScript extends Script {
+
+    /** Script version displayed in the overlay. */
+    public static final String VERSION = "1.2";
+    public static String status = "";
+    /** Total profit made in gp. */
+    public static long profit = 0L;
+    /** Profit per hour in gp. */
+    public static long profitPerHour = 0L;
+
+    private static final int MAX_SLOTS = 3;
+    private static final long TRADE_COOLDOWN = 4 * 60 * 60 * 1000L;
+    private long buyTimeoutMs = 25 * 60 * 1000L;
+
+    private static final List<String> DEFAULT_ITEMS = Arrays.asList(
+            "Air rune", "Mind rune", "Water rune", "Earth rune", "Fire rune",
+            "Body rune", "Chaos rune", "Nature rune", "Death rune", "Law rune",
+            "Steel bar", "Iron ore", "Coal", "Mithril ore", "Adamantite ore",
+            "Runite ore", "Oak plank", "Lobster", "Swordfish", "Tuna"
+    );
+
+    private static class Offer {
+        String name;
+        int buyPrice;
+        int sellPrice;
+        int quantity;
+        boolean selling;
+        long placedTime;
+    }
+
+    private final List<Offer> offers = new ArrayList<>();
+    private final Queue<String> itemQueue = new LinkedList<>();
+    private final Map<String, Long> lastTrade = new HashMap<>();
+
+    public static long startTime;
+    private final Rs2ItemManager itemManager = new Rs2ItemManager();
+    private GEFlipperConfig config;
+    private List<String> items = new ArrayList<>();
+
+
+    public boolean run(GEFlipperConfig config) {
+        if (isRunning()) {
+            shutdown();
+        }
+        offers.clear();
+        itemQueue.clear();
+        lastTrade.clear();
+
+        this.config = config;
+        final GEFlipperConfig conf = this.config;
+        buyTimeoutMs = conf.cancelMinutes() * 60L * 1000L;
+        Rs2Antiban.resetAntibanSettings();
+        Rs2AntibanSettings.naturalMouse = true;
+        status = "Starting";
+        // items will be loaded after login
+        items = new ArrayList<>();
+        itemQueue.clear();
+        itemQueue.addAll(items);
+        startTime = System.currentTimeMillis();
+        profit = 0;
+        profitPerHour = 0;
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) return;
+                if (!super.run()) return;
+
+                if (items.isEmpty()) {
+                    items = getTradeableF2PItems();
+                    itemQueue.addAll(items);
+                    if (items.isEmpty()) {
+                        status = "Starting";
+                        return;
+                    }
+                }
+
+                if (BreakHandlerScript.breakIn > 0 && BreakHandlerScript.breakIn <= 180) {
+                    status = "Waiting for break";
+                    if (Rs2GrandExchange.isOpen()) {
+                        Rs2GrandExchange.closeExchange();
+                    }
+                    return;
+                }
+
+                if (!Rs2GrandExchange.isOpen()) {
+                    Rs2GrandExchange.openExchange();
+                    if (!Rs2GrandExchange.isOpen()) {
+                        status = "Opening GE";
+                        return;
+                    }
+                }
+
+                // collect finished offers
+                if (Rs2GrandExchange.hasBoughtOffer()) {
+                    status = "Collecting";
+                    Rs2GrandExchange.collect(false);
+                }
+                if (Rs2GrandExchange.hasSoldOffer()) {
+                    status = "Collecting";
+                    Rs2GrandExchange.collect(true);
+                    for (Iterator<Offer> it = offers.iterator(); it.hasNext();) {
+                        Offer o = it.next();
+                        if (o.selling && !Rs2Inventory.hasItem(o.name)) {
+                            profit += (o.sellPrice - o.buyPrice) * o.quantity;
+                            long runtime = System.currentTimeMillis() - startTime;
+                            if (runtime > 0) {
+                                profitPerHour = (int) (profit * 3600000L / runtime);
+                            }
+                            it.remove();
+                        }
+                    }
+                }
+
+                // cancel stale buy offers
+                for (Offer o : new ArrayList<>(offers)) {
+                    if (!o.selling && !Rs2Inventory.hasItem(o.name)) {
+                        if (System.currentTimeMillis() - o.placedTime > buyTimeoutMs) {
+                            status = "Cancelling";
+                            Rs2GrandExchange.abortOffer(o.name, false);
+                            offers.remove(o);
+                            itemQueue.add(o.name);
+                            lastTrade.remove(o.name);
+                        }
+                    }
+                }
+
+                // place sell offers for bought items
+                for (Offer o : new ArrayList<>(offers)) {
+                    if (!o.selling && Rs2Inventory.hasItem(o.name)) {
+                        status = "Selling";
+                        Rs2GrandExchange.sellItem(o.name, o.quantity, o.sellPrice);
+                        o.selling = true;
+                    }
+                    if (o.selling && !Rs2Inventory.hasItem(o.name)) {
+                        offers.remove(o);
+                    }
+                }
+
+                // place buy offers if slots available
+                if (offers.size() >= MAX_SLOTS) {
+                    status = "Waiting";
+                }
+                int attempts = 0;
+                boolean placedSomething = false;
+                while (offers.size() < MAX_SLOTS && attempts < items.size()) {
+                    attempts++;
+                    String name = nextItem();
+                    if (name == null) {
+                        status = "All items on cooldown";
+                        break;
+                    }
+                    int id = itemManager.getItemId(name);
+                    if (id <= 0) {
+                        status = "Item not found";
+                        continue;
+                    }
+                    int buyPrice = Rs2GrandExchange.getOfferPrice(id);
+                    int sellPrice = Rs2GrandExchange.getSellPrice(id);
+                    if (buyPrice <= 0 || sellPrice <= 0) {
+                        status = "Price lookup failed";
+                        continue;
+                    }
+                    int buyVol = Rs2GrandExchange.getBuyingVolume(id);
+                    int sellVol = Rs2GrandExchange.getSellingVolume(id);
+                    int volume = Math.min(buyVol, sellVol);
+                    if (volume > 0 && volume < conf.minVolume()) {
+                        status = "Volume too low";
+                        itemQueue.add(name);
+                        continue;
+                    }
+                    int coins = Rs2Inventory.itemQuantity(ItemID.COINS_995);
+                    if (coins < buyPrice) {
+                        status = "Not enough gp";
+                        itemQueue.add(name);
+                        continue;
+                    }
+                    int quantity = coins / ((MAX_SLOTS - offers.size()) * buyPrice);
+                    if (quantity <= 0) {
+                        quantity = coins / buyPrice;
+                    }
+                    if (quantity <= 0) {
+                        status = "Not enough gp";
+                        continue;
+                    }
+
+                    // respect GE buy limits
+                    int buyLimit = 0;
+                    var stats = Microbot.getItemManager().getItemStats(id);
+                    if (stats != null) {
+                        buyLimit = stats.getGeLimit();
+                    }
+                    if (buyLimit > 0 && quantity > buyLimit) {
+                        quantity = buyLimit;
+                    }
+                    boolean placed = Rs2GrandExchange.buyItem(name, buyPrice, quantity);
+                    if (!placed) {
+                        status = "Unable to buy";
+                        break;
+                    }
+                    placedSomething = true;
+                    lastTrade.put(name, System.currentTimeMillis());
+                    Offer offer = new Offer();
+                    offer.name = name;
+                    offer.buyPrice = buyPrice;
+                    offer.sellPrice = sellPrice;
+                    offer.quantity = quantity;
+                    offer.selling = false;
+                    offer.placedTime = System.currentTimeMillis();
+                    offers.add(offer);
+                }
+                if (!placedSomething) {
+                    status = "Waiting";
+                }
+
+
+            } catch (Exception ex) {
+                Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
+            }
+        }, 0, conf.delay(), TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        Rs2Antiban.resetAntibanSettings();
+        offers.clear();
+        itemQueue.clear();
+        lastTrade.clear();
+        profit = 0;
+        profitPerHour = 0;
+        status = "Stopped";
+    }
+
+    private String nextItem() {
+        if (items.isEmpty()) {
+            items = getTradeableF2PItems();
+            itemQueue.addAll(items);
+            if (items.isEmpty()) {
+                return null;
+            }
+        }
+        int attempts = 0;
+        long now = System.currentTimeMillis();
+        while (attempts < items.size()) {
+            if (itemQueue.isEmpty()) {
+                itemQueue.addAll(items);
+            }
+            String name = itemQueue.poll();
+            Long last = lastTrade.get(name);
+            if (last != null && now - last < TRADE_COOLDOWN) {
+                attempts++;
+                continue;
+            }
+            // item cooldowns only based on trade history now
+            return name;
+        }
+        return null;
+    }
+
+    public List<String> getTradeableF2PItems() {
+        List<String> names = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+            List<String> list = new ArrayList<>();
+            int count = Microbot.getClient().getItemCount();
+            for (int id = 0; id < count; id++) {
+                ItemComposition comp = Microbot.getItemManager().getItemComposition(id);
+                if (comp != null && comp.isTradeable() && !comp.isMembers()) {
+                    list.add(comp.getName());
+                }
+            }
+            return list;
+        }).orElse(new ArrayList<>());
+
+        if (names.isEmpty()) {
+            names.addAll(DEFAULT_ITEMS);
+        }
+        return names;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/item/Rs2ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/item/Rs2ItemManager.java
@@ -26,13 +26,17 @@ public class Rs2ItemManager {
         if (query == null || query.trim().isEmpty()) {
             return Collections.emptyList();
         }
-        String lowerQuery = query.toLowerCase();
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getItemManager().search(query)).orElse(Collections.emptyList());
+        return Microbot.getClientThread().runOnClientThreadOptional(
+                () -> Microbot.getItemManager().search(query)
+        ).orElse(Collections.emptyList());
     }
 
     // get item id by name
     public int getItemId(String itemName) {
-        var items =searchItem(itemName);
+        var items = searchItem(itemName);
+        if (items.isEmpty()) {
+            return -1;
+        }
         return items.get(0).getId();
     }
 


### PR DESCRIPTION
## Summary
- add GE Flipper overlay displaying status, profit and hourly profit
- implement GE flipping script that cycles F2P items
- include helper for fetching tradeable F2P items with fallback list
- add margin check when buying items
- tweak version constant and clean imports
- remove item name config so items are loaded dynamically
- **remove margin check** so the flipper buys at low price and sells high without margin restrictions
- prevent freeze when GE window first opens

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f162938dc8330a1d8ab3e6fc939e3