### PR TITLE
Add GE Flipper plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperConfig.java
@@ -1,0 +1,24 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("geflipper")
+public interface GEFlipperConfig extends Config {
+    @ConfigItem(
+            keyName = "cancelMinutes",
+            name = "Cancel After Minutes",
+            description = "Abort offers after this many minutes",
+            position = 0
+    )
+    default int cancelAfterMinutes() { return 15; }
+
+    @ConfigItem(
+            keyName = "useVolume",
+            name = "Use Trade Volume",
+            description = "Only flip items with trade volume",
+            position = 1
+    )
+    default boolean useTradeVolume() { return false; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperOverlay.java
@@ -1,0 +1,46 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.misc.TimeUtils;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.time.Instant;
+
+public class GEFlipperOverlay extends OverlayPanel {
+    private final GEFlipperPlugin plugin;
+
+    @Inject
+    GEFlipperOverlay(GEFlipperPlugin plugin) {
+        super(plugin);
+        this.plugin = plugin;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.setPreferredSize(new Dimension(200, 100));
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("GE Flipper V" + GEFlipperPlugin.VERSION)
+                .color(Color.GREEN)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Profit:")
+                .right(Long.toString(plugin.getProfit()))
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Profit p/h:")
+                .right(Long.toString(plugin.getProfitPerHour()))
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Run Time:")
+                .right(TimeUtils.getFormattedDurationBetween(plugin.getStartTime(), Instant.now()))
+                .build());
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperPlugin.java
@@ -1,0 +1,58 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import com.google.inject.Provides;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.time.Instant;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "GE Flipper",
+        description = "Microbot grand exchange flipper",
+        tags = {"ge", "flipper", "microbot"},
+        enabledByDefault = false
+)
+@Slf4j
+public class GEFlipperPlugin extends Plugin {
+    static final String VERSION = "1.0";
+
+    @Inject
+    private GEFlipperConfig config;
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private GEFlipperOverlay overlay;
+    @Inject
+    private GEFlipperScript script;
+
+    @Getter
+    private Instant startTime;
+
+    @Provides
+    GEFlipperConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(GEFlipperConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws AWTException {
+        startTime = Instant.now();
+        overlayManager.add(overlay);
+        script.run(this, config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+
+    long getProfit() { return script.getProfit(); }
+    long getProfitPerHour() { return script.getProfitPerHour(); }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GEFlipperScript.java
@@ -1,0 +1,127 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.api.ItemComposition;
+import net.runelite.client.game.ItemStats;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeSlots;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class GEFlipperScript extends Script {
+    private GEFlipperPlugin plugin;
+    private GEFlipperConfig config;
+    private final Random random = new Random();
+
+    private final Map<Integer, Integer> bought = new HashMap<>();
+    private final Map<GrandExchangeSlots, Instant> offerTimes = new HashMap<>();
+    private final List<ItemComposition> f2pItems = new ArrayList<>();
+    private long profit = 0;
+
+    long getProfit() { return profit; }
+    long getProfitPerHour() {
+        Duration runtime = getRunTime();
+        double hours = runtime.toMillis() / 3600000.0;
+        if (hours <= 0) return 0;
+        return (long) (profit / hours);
+    }
+
+    public boolean run(GEFlipperPlugin plugin, GEFlipperConfig config) {
+        this.plugin = plugin;
+        this.config = config;
+        Rs2AntibanSettings.naturalMouse = true;
+        loadF2P();
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn() || !super.run()) return;
+
+                if (BreakHandlerScript.breakIn > 0 && BreakHandlerScript.breakIn <= 180 && !BreakHandlerScript.isBreakActive()) {
+                    Microbot.status = "Waiting for break";
+                    Rs2GrandExchange.closeExchange();
+                    return;
+                }
+
+                if (!Rs2GrandExchange.isOpen()) {
+                    Rs2GrandExchange.openExchange();
+                    return;
+                }
+
+                cancelOldOffers();
+
+                if (Rs2GrandExchange.hasBoughtOffer()) {
+                    Rs2GrandExchange.collectToInventory();
+                }
+                if (Rs2GrandExchange.hasSoldOffer()) {
+                    Rs2GrandExchange.collectToInventory();
+                }
+
+                if (Rs2GrandExchange.getAvailableSlot().getLeft() == null) {
+                    return;
+                }
+
+                ItemComposition item = f2pItems.get(random.nextInt(f2pItems.size()));
+                ItemStats stats = Microbot.getItemManager().getItemStats(item.getId());
+                if (stats == null) return;
+                int limit = stats.getGeLimit();
+                int count = bought.getOrDefault(item.getId(), 0);
+                if (limit > 0 && count >= limit) return;
+                if (limit > 0 && count >= limit - 1) return;
+
+                if (config.useTradeVolume() && Rs2GrandExchange.getBuyingVolume(item.getId()) < 1000) return;
+
+                int price = Rs2GrandExchange.getPrice(item.getId());
+                if (price <= 0) return;
+                int buyPrice = (int) (price * 0.95);
+                boolean placed = Rs2GrandExchange.buyItem(item.getName(), buyPrice, 1);
+                if (placed) {
+                    offerTimes.put(Rs2GrandExchange.getAvailableSlot().getLeft(), Instant.now());
+                    bought.put(item.getId(), count + 1);
+                    int sellPrice = (int) (price * 1.05);
+                    if (Rs2GrandExchange.hasFinishedBuyingOffers()) {
+                        Rs2GrandExchange.collectToInventory();
+                        if (Rs2GrandExchange.sellItem(item.getName(), 1, sellPrice)) {
+                            profit += sellPrice - buyPrice;
+                        }
+                    }
+                }
+
+            } catch (Exception ex) {
+                Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
+            }
+        }, 0, 3000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private void loadF2P() {
+        Microbot.getClientThread().runOnClientThread(() -> {
+            for (int id = 0; id <= 30890; id++) {
+                ItemComposition ic = Microbot.getItemManager().getItemComposition(id);
+                if (ic != null && !ic.isMembers() && ic.isTradeable()) {
+                    f2pItems.add(ic);
+                }
+            }
+            return null;
+        });
+    }
+
+    private void cancelOldOffers() {
+        Instant now = Instant.now();
+        for (GrandExchangeSlots slot : GrandExchangeSlots.values()) {
+            if (!Rs2GrandExchange.isSlotAvailable(slot)) {
+                Instant time = offerTimes.get(slot);
+                if (time != null && Duration.between(time, now).toMinutes() >= config.cancelAfterMinutes()) {
+                    Rs2GrandExchange.abortAllOffers(true);
+                    offerTimes.clear();
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add GE Flipper plugin with config, overlay, and script
- use GE functions to buy/sell items while observing limits
- display profit, profit per hour and runtime
- fix missing return in client thread task

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686447fa50608330b62477946afaa58d