### PR TITLE
Add Random Trainer plugin

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -27,6 +27,7 @@
       * [Rs2Widget](api/apidocs/net/runelite/client/plugins/microbot/util/widget/Rs2Widget.html)
     - **Script Examples**
         * [Fighter Script](combat.md)
+        * [Random Trainer](randomtrainer-plugin.md)
     - **Plugin Scheduler**
       * [Overview](scheduler/README.md)
       * [User Guide](scheduler/user-guide.md)

--- a/docs/randomtrainer-plugin.md
+++ b/docs/randomtrainer-plugin.md
@@ -1,0 +1,12 @@
+# Random Trainer Plugin
+
+The Random Trainer plugin selects a skill at random and starts the appropriate microbot plugin.  Currently only mining is implemented while other skills are placeholders.
+
+**Features**
+
+* Customize the delay between random skill selections (in minutes)
+* Combat section with goals for Attack, Strength, Defence, Ranged and Magic
+* Optionally heal when your hitpoints fall below a configured value
+* Works with BreakHandler to idle at a bank three minutes before a break
+
+When Mining is under level 15 the script equips the best available pickaxe from your bank, mines tin and copper evenly in Varrock East, and banks the ore when your inventory is full.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerConfig.java
@@ -1,0 +1,89 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+
+@ConfigGroup(RandomTrainerConfig.GROUP)
+public interface RandomTrainerConfig extends Config {
+    String GROUP = "randomtrainer";
+
+    @ConfigSection(
+            name = "General",
+            description = "General settings",
+            position = 0
+    )
+    String generalSection = "general";
+
+    @ConfigItem(
+            keyName = "switchDelay",
+            name = "Skill Switch Delay (min)",
+            description = "Time in minutes between selecting a new skill to train",
+            position = 0,
+            section = generalSection
+    )
+    default int switchDelay() { return 10; }
+
+    @ConfigSection(
+            name = "Combat",
+            description = "Combat Training Goals",
+            position = 1
+    )
+    String combatSection = "combat";
+
+    @ConfigItem(
+            keyName = "attackLevels",
+            name = "Attack Levels",
+            description = "Levels of Attack to train",
+            position = 0,
+            section = combatSection
+    )
+    default int attackLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "strengthLevels",
+            name = "Strength Levels",
+            description = "Levels of Strength to train",
+            position = 1,
+            section = combatSection
+    )
+    default int strengthLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "defenceLevels",
+            name = "Defence Levels",
+            description = "Levels of Defence to train",
+            position = 2,
+            section = combatSection
+    )
+    default int defenceLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "rangedLevels",
+            name = "Ranged Levels",
+            description = "Levels of Ranged to train",
+            position = 3,
+            section = combatSection
+    )
+    default int rangedLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "mageLevels",
+            name = "Mage Levels",
+            description = "Levels of Magic to train",
+            position = 4,
+            section = combatSection
+    )
+    default int mageLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "healAtHp",
+            name = "Heal at HP",
+            description = "Eat food when HP is at or below this amount",
+            position = 5,
+            section = combatSection
+    )
+    default int healAtHp() { return 0; }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerOverlay.java
@@ -1,0 +1,41 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class RandomTrainerOverlay extends OverlayPanel {
+    private final RandomTrainerScript script;
+
+    @Inject
+    public RandomTrainerOverlay(RandomTrainerPlugin plugin, RandomTrainerScript script) {
+        super(plugin);
+        this.script = script;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.getChildren().clear();
+        panelComponent.setPreferredSize(new Dimension(200, 80));
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("Random Trainer V" + RandomTrainerScript.VERSION)
+                .color(Color.GREEN)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder().build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status: " + Microbot.status)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Current Task: " + script.getCurrentTaskName())
+                .build());
+        return super.render(graphics);
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerPlugin.java
@@ -1,0 +1,52 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import com.google.inject.Provides;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "Random Trainer",
+        description = "Trains random skills",
+        tags = {"random", "trainer", "microbot"},
+        enabledByDefault = false
+)
+public class RandomTrainerPlugin extends Plugin {
+    // Script version for display in the overlay
+    static final String VERSION = RandomTrainerScript.VERSION;
+    @Inject
+    private RandomTrainerConfig config;
+
+    @Provides
+    RandomTrainerConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(RandomTrainerConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private RandomTrainerOverlay overlay;
+    @Inject
+    private RandomTrainerScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        overlayManager.add(overlay);
+        script.run(config, this);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+
+    public boolean isBreakHandlerEnabled() {
+        return net.runelite.client.plugins.microbot.Microbot.isPluginEnabled(net.runelite.client.plugins.microbot.breakhandler.BreakHandlerPlugin.class);
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerScript.java
@@ -1,0 +1,229 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import net.runelite.client.plugins.microbot.mining.AutoMiningPlugin;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.Skill;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+public class RandomTrainerScript extends Script {
+    public static final String VERSION = "1.0.0";
+
+    private RandomTrainerConfig config;
+    private RandomTrainerPlugin plugin;
+    private SkillTask currentTask;
+    private long nextSwitch;
+    private final Random random = new Random();
+    // flag to avoid clicking a rock multiple times before mining starts
+    private boolean waitingForAnim = false;
+    private boolean idleForBreak = false;
+
+    public boolean run(RandomTrainerConfig config, RandomTrainerPlugin plugin) {
+        this.config = config;
+        this.plugin = plugin;
+        nextSwitch = System.currentTimeMillis() + config.switchDelay() * 60_000L;
+        selectNewTask();
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(this::loop, 0, 1, TimeUnit.SECONDS);
+        return true;
+    }
+
+    public SkillTask getCurrentTask() {
+        return currentTask;
+    }
+
+    public String getCurrentTaskName() {
+        if (currentTask == null) {
+            return "None";
+        }
+        String n = currentTask.name().toLowerCase();
+        return Character.toUpperCase(n.charAt(0)) + n.substring(1);
+    }
+
+    private void loop() {
+        try {
+            if (!super.run() || !Microbot.isLoggedIn()) return;
+
+            if (shouldIdleForBreak()) {
+                handleUpcomingBreak();
+                return;
+            } else if (idleForBreak) {
+                idleForBreak = false;
+            }
+
+            if (config.healAtHp() > 0) {
+                int hp = Microbot.getClient().getBoostedSkillLevel(Skill.HITPOINTS);
+                if (hp <= config.healAtHp()) {
+                    Rs2Player.useFood();
+                }
+            }
+
+            if (System.currentTimeMillis() >= nextSwitch) {
+                stopCurrentTask();
+                selectNewTask();
+                nextSwitch = System.currentTimeMillis() + config.switchDelay() * 60_000L;
+            }
+
+            executeCurrentTask();
+        } catch (Exception ex) {
+            Microbot.log(ex.getMessage());
+        }
+    }
+
+    private boolean shouldIdleForBreak() {
+        return plugin.isBreakHandlerEnabled() && BreakHandlerScript.breakIn > 0 && BreakHandlerScript.breakIn <= 180;
+    }
+
+    private void handleUpcomingBreak() {
+        Microbot.status = "Break soon, idling at bank";
+        if (!idleForBreak) {
+            Rs2Bank.walkToBankAndUseBank();
+            idleForBreak = true;
+        }
+        sleep(1000);
+    }
+
+    private void selectNewTask() {
+        SkillTask[] tasks = SkillTask.values();
+        SkillTask newTask;
+        do {
+            newTask = tasks[random.nextInt(tasks.length)];
+        } while (newTask == currentTask);
+
+        currentTask = newTask;
+        Microbot.status = "Selected " + currentTask.name();
+    }
+
+    private void executeCurrentTask() {
+        Microbot.status = "Training " + currentTask.name();
+        switch (currentTask) {
+            case MINING:
+                if (Rs2Player.getRealSkillLevel(Skill.MINING) < 15) {
+                    trainLowLevelMining();
+                } else {
+                    startPlugin(AutoMiningPlugin.class);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void stopCurrentTask() {
+        switch (currentTask) {
+            case MINING:
+                stopPlugin(AutoMiningPlugin.class);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void trainLowLevelMining() {
+        if (!ensurePickaxe()) {
+            return;
+        }
+
+        if (Rs2Inventory.isFull()) {
+            if (Rs2Bank.walkToBankAndUseBank()) {
+                Rs2Bank.depositAll("tin ore");
+                Rs2Bank.depositAll("copper ore");
+            }
+            return;
+        }
+
+        WorldPoint mine = new WorldPoint(3288, 3363, 0);
+        if (Rs2Player.getWorldLocation().distanceTo(mine) > 5) {
+            Rs2Walker.walkTo(mine);
+            return;
+        }
+        // if we've clicked a rock and the animation hasn't started yet, wait
+        if (waitingForAnim) {
+            if (Rs2Player.isAnimating()) {
+                waitingForAnim = false; // animation started
+            }
+            return;
+        }
+
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            return; // wait until mining animation has finished
+        }
+
+        int tinCount = Rs2Inventory.itemQuantity("tin ore");
+        int copperCount = Rs2Inventory.itemQuantity("copper ore");
+        String rockName = tinCount <= copperCount ? "Tin rocks" : "Copper rocks";
+
+        var rock = Rs2GameObject.findReachableObject(rockName, true, 10, mine);
+        if (rock != null && Rs2GameObject.interact(rock)) {
+            waitingForAnim = true; // avoid spam clicking until animation begins
+            Rs2Player.waitForXpDrop(Skill.MINING, true);
+        }
+    }
+
+    private boolean ensurePickaxe() {
+        if (Rs2Equipment.isWearing(item -> item.getName().toLowerCase().contains("pickaxe")) ||
+                Rs2Inventory.hasItem("pickaxe")) {
+            // attempt to wield if not equipped
+            if (!Rs2Equipment.isWearing(item -> item.getName().toLowerCase().contains("pickaxe"))) {
+                Rs2Inventory.interact("pickaxe", "Wield");
+            }
+            return true;
+        }
+
+        if (!Rs2Bank.isOpen()) {
+            Rs2Bank.walkToBankAndUseBank();
+            return false;
+        }
+
+        int level = Rs2Player.getRealSkillLevel(Skill.MINING);
+        String[] pickaxes = {
+                "Rune pickaxe",
+                "Adamant pickaxe",
+                "Mithril pickaxe",
+                "Black pickaxe",
+                "Steel pickaxe",
+                "Iron pickaxe",
+                "Bronze pickaxe"
+        };
+        int[] requirements = {41, 31, 21, 11, 6, 1, 1};
+        String chosen = null;
+        for (int i = 0; i < pickaxes.length; i++) {
+            if (level >= requirements[i] && Rs2Bank.hasItem(pickaxes[i])) {
+                Rs2Bank.withdrawItem(true, pickaxes[i]);
+                chosen = pickaxes[i];
+                break;
+            }
+        }
+        Rs2Bank.closeBank();
+        if (chosen != null) {
+            Rs2Inventory.interact(chosen, "Wield");
+        }
+        return Rs2Equipment.isWearing(item -> item.getName().toLowerCase().contains("pickaxe"))
+                || Rs2Inventory.hasItem("pickaxe");
+    }
+
+    private void startPlugin(Class<? extends Plugin> clazz) {
+        Plugin p = Microbot.getPlugin(clazz.getName());
+        if (p != null && !Microbot.isPluginEnabled(clazz)) {
+            Microbot.startPlugin(p);
+        }
+    }
+
+    private void stopPlugin(Class<? extends Plugin> clazz) {
+        Plugin p = Microbot.getPlugin(clazz.getName());
+        if (p != null && Microbot.isPluginEnabled(clazz)) {
+            Microbot.stopPlugin(p);
+        }
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/SkillTask.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/SkillTask.java
@@ -1,0 +1,15 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+public enum SkillTask {
+    MINING,
+    SMITHING,
+    CRAFTING,
+    WOODCUTTING,
+    RUNECRAFTING,
+    FIREMAKING,
+    FISHING,
+    COOKING,
+    RANGED,
+    PRAYER
+
+}


### PR DESCRIPTION
## Summary
- implement Random Trainer plugin that picks skills randomly and idles at bank before breaks
- add combat configuration with heal-at-HP option
- overlay shows current status and task
- ensure overlay uses formatted task name
- prevent repeated rock clicks by waiting for mining animation
- fix class endings
- integrate AutoMining-style rock detection in low-level mining

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686580a0194083308c93dedcc767e3c5