### PR TITLE
Add tool upgrade checks when banking

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -27,6 +27,7 @@
       * [Rs2Widget](api/apidocs/net/runelite/client/plugins/microbot/util/widget/Rs2Widget.html)
     - **Script Examples**
         * [Fighter Script](combat.md)
+        * [Random Trainer](randomtrainer-plugin.md)
     - **Plugin Scheduler**
       * [Overview](scheduler/README.md)
       * [User Guide](scheduler/user-guide.md)

--- a/docs/randomtrainer-plugin.md
+++ b/docs/randomtrainer-plugin.md
@@ -1,0 +1,19 @@
+# Random Trainer Plugin
+
+The Random Trainer plugin selects a skill at random and then trains it.  Mining and low level woodcutting are implemented while other skills are placeholders.
+
+**Features**
+
+* Customize the delay between random skill selections **in minutes**
+* Combat section with goals for Attack, Strength, Defence, Ranged and Magic
+* Optionally heal when your hitpoints fall below a configured "Heal at HP" value
+* Works with BreakHandler to idle at a bank three minutes before a break
+* Before each new task the bot deposits the entire inventory so it starts with an empty backpack
+* Uses antiban features like contextual variability and dynamic activity
+
+When Mining is below level 15 the script equips the best available pickaxe from your bank, mines tin and copper evenly in Varrock East, and banks the ore when your inventory is full.  It will only wield a pickaxe if your Attack level meets the requirement (e.g. 40 for rune, 30 for adamant). Once you have at least level 15 it walks to 2970,3239 and mines iron rocks instead.  When your inventory is full it uses the nearest deposit box to store everything except your pickaxe before returning to the mine. After reaching level 30 the miner travels to 3083,3422 to mine coal. When the inventory is full it runs to the nearest bank, deposits all ore, and returns to mining.  Any uncut gems (sapphire, emerald, ruby, and diamond) found while mining are also deposited.
+
+If Woodcutting is below level 15 the trainer withdraws the best axe your account can use and heads to 3162,3454 to chop normal trees. When that area is crowded (more than three other players nearby) it instead uses an alternate tree patch at 3276,3444. Logs are banked at the nearest bank before returning to chop more trees. Once Woodcutting reaches level 15 it walks to 3192,3461 and chops oak trees until level 30, banking logs whenever the inventory fills. Between levels 30 and 60 it travels to 3060,3254 and chops willow trees. When the inventory is full it walks to the deposit box at 3046,3235 to store all willow logs before returning.
+
+
+When Fishing is below level 20 the trainer withdraws a small fishing net from your bank and heads to 3244,3154 to fish shrimp and anchovies. Once the inventory is full it walks upstairs in Lumbridge to the bank chest at 3209,3220,2 and deposits all raw shrimp and raw anchovies before resuming. After reaching level 20 it withdraws a fly fishing rod and feathers, then travels to 3104,3431 to lure fish. When the inventory becomes full it banks the fish at the nearest bank while keeping the rod and feathers.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/FishingTrainer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/FishingTrainer.java
@@ -1,0 +1,182 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FishingTrainer implements SkillTrainer {
+    private final RandomTrainerScript script;
+    private boolean waitingForAnim = false;
+    private long animWaitStart = 0L;
+
+    // use the exact item name so the script can withdraw it from the bank
+    private static final List<String> FISHING_NET = Arrays.asList("small fishing net");
+    private static final List<String> FLY_FISH_GEAR = Arrays.asList("Fly fishing rod", "Feather");
+
+    public FishingTrainer(RandomTrainerScript script) {
+        this.script = script;
+    }
+
+    private boolean ensureGear() {
+        int lvl = Rs2Player.getRealSkillLevel(Skill.FISHING);
+        if (lvl < 20) {
+            if (Rs2Inventory.hasItem(FISHING_NET.get(0))) {
+                return true;
+            }
+            if (!Rs2Bank.isOpen()) {
+                Microbot.status = "Walking to Bank";
+                Rs2Bank.walkToBankAndUseBank();
+                return false;
+            }
+            Rs2Bank.withdrawItem(true, FISHING_NET.get(0));
+            Rs2Bank.closeBank();
+            return Rs2Inventory.hasItem(FISHING_NET.get(0));
+        } else {
+            boolean hasRod = Rs2Inventory.hasItem("Fly fishing rod");
+            boolean hasFeather = Rs2Inventory.hasItem("Feather");
+            if (hasRod && hasFeather) return true;
+            if (!Rs2Bank.isOpen()) {
+                Microbot.status = "Walking to Bank";
+                Rs2Bank.walkToBankAndUseBank();
+                return false;
+            }
+            if (!hasRod) {
+                Rs2Bank.withdrawItem(true, "Fly fishing rod");
+            }
+            if (!hasFeather) {
+                Rs2Bank.withdrawAll(false, "Feather");
+            }
+            Rs2Bank.closeBank();
+            return Rs2Inventory.hasItem("Fly fishing rod") && Rs2Inventory.hasItem("Feather");
+        }
+    }
+
+    private void bankLowLevelFish() {
+        if (!Rs2Bank.isOpen()) {
+            Rs2Bank.walkToBankAndUseBank();
+        }
+        Rs2Bank.depositAll("Raw shrimps");
+        Rs2Bank.depositAll("Raw anchovies");
+        Rs2Bank.closeBank();
+    }
+
+    private void bankHighLevelFish() {
+        if (!Rs2Bank.isOpen()) {
+            Rs2Bank.walkToBankAndUseBank();
+        }
+        Rs2Bank.depositAllExcept("Fly fishing rod", "Feather");
+        Rs2Bank.closeBank();
+    }
+
+    private boolean atLocation(WorldPoint wp) {
+        return Rs2Player.getWorldLocation().distanceTo(wp) <= 5;
+    }
+
+    public void trainLowLevelFishing() {
+        if (!ensureGear()) {
+            Microbot.status = "Getting net";
+            return;
+        }
+        if (Rs2Inventory.isFull()) {
+            Microbot.status = "Banking fish";
+            bankLowLevelFish();
+            return;
+        }
+        WorldPoint spot = new WorldPoint(3244, 3154, 0);
+        if (!atLocation(spot)) {
+            Microbot.status = "Walking to spot";
+            Rs2Walker.walkTo(spot);
+            return;
+        }
+        script.startSwitchTimerIfNeeded();
+        if (waitingForAnim) {
+            if (Rs2Player.isAnimating()) {
+                waitingForAnim = false;
+                Microbot.status = "Fishing";
+            } else if (System.currentTimeMillis() - animWaitStart > 5000) {
+                waitingForAnim = false;
+                Microbot.status = "Idle";
+            } else {
+                return;
+            }
+        }
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            Microbot.status = "Fishing";
+            return;
+        }
+        Rs2NpcModel npc = Rs2Npc.getNpcs("Fishing spot").findFirst().orElse(null);
+        npc = Rs2Npc.validateInteractable(npc);
+        if (npc != null && Rs2Npc.interact(npc, "Net")) {
+            waitingForAnim = true;
+            animWaitStart = System.currentTimeMillis();
+            Rs2Player.waitForXpDrop(Skill.FISHING, true);
+            Rs2Antiban.actionCooldown();
+        } else {
+            Microbot.status = "Idle";
+        }
+    }
+
+    public void trainFlyFishing() {
+        if (!ensureGear()) {
+            Microbot.status = "Getting rod";
+            return;
+        }
+        if (Rs2Inventory.isFull()) {
+            Microbot.status = "Banking fish";
+            bankHighLevelFish();
+            return;
+        }
+        WorldPoint spot = new WorldPoint(3104, 3431, 0);
+        if (!atLocation(spot)) {
+            Microbot.status = "Walking to spot";
+            Rs2Walker.walkTo(spot);
+            return;
+        }
+        script.startSwitchTimerIfNeeded();
+        if (waitingForAnim) {
+            if (Rs2Player.isAnimating()) {
+                waitingForAnim = false;
+                Microbot.status = "Fishing";
+            } else if (System.currentTimeMillis() - animWaitStart > 5000) {
+                waitingForAnim = false;
+                Microbot.status = "Idle";
+            } else {
+                return;
+            }
+        }
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            Microbot.status = "Fishing";
+            return;
+        }
+        Rs2NpcModel npc = Rs2Npc.getNpcs("Fishing spot").findFirst().orElse(null);
+        npc = Rs2Npc.validateInteractable(npc);
+        if (npc != null && Rs2Npc.interact(npc, "Lure")) {
+            waitingForAnim = true;
+            animWaitStart = System.currentTimeMillis();
+            Rs2Player.waitForXpDrop(Skill.FISHING, true);
+            Rs2Antiban.actionCooldown();
+        } else {
+            Microbot.status = "Idle";
+        }
+    }
+
+    @Override
+    public void train() {
+        int level = Rs2Player.getRealSkillLevel(Skill.FISHING);
+        if (level < 20) {
+            trainLowLevelFishing();
+        } else {
+            trainFlyFishing();
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/MiningTrainer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/MiningTrainer.java
@@ -1,0 +1,287 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.depositbox.Rs2DepositBox;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import java.util.Arrays;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.GameObject;
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.microbot.randomtrainer.RandomTrainerScript;
+
+public class MiningTrainer implements SkillTrainer {
+    private final RandomTrainerScript script;
+    private static final String[] PICKAXES = {
+            "Rune pickaxe",
+            "Adamant pickaxe",
+            "Mithril pickaxe",
+            "Black pickaxe",
+            "Steel pickaxe",
+            "Iron pickaxe",
+            "Bronze pickaxe"
+    };
+
+    private static final int[] MINING_REQ = {41, 31, 21, 11, 6, 1, 1};
+    private static final int[] ATTACK_REQ = {40, 30, 20, 10, 5, 1, 1};
+
+    private boolean waitingForAnim = false;
+    private long animWaitStart = 0L;
+
+    public MiningTrainer(RandomTrainerScript script) {
+        this.script = script;
+    }
+
+    private boolean ensurePickaxe() {
+        int miningLevel = Rs2Player.getRealSkillLevel(Skill.MINING);
+        int attackLevel = Rs2Player.getRealSkillLevel(Skill.ATTACK);
+
+        int bestIndex = PICKAXES.length - 1;
+        for (int i = 0; i < PICKAXES.length; i++) {
+            if (miningLevel >= MINING_REQ[i]) {
+                bestIndex = i;
+                break;
+            }
+        }
+
+        int currentIndex = -1;
+        for (int i = 0; i < PICKAXES.length; i++) {
+            String name = PICKAXES[i];
+            if (Rs2Equipment.isWearing(eq -> eq.getName().equalsIgnoreCase(name)) || Rs2Inventory.hasItem(name)) {
+                currentIndex = i;
+                break;
+            }
+        }
+
+        if (currentIndex != -1 && currentIndex <= bestIndex) {
+            final int idx = currentIndex;
+            if (!Rs2Equipment.isWearing(eq -> eq.getName().equalsIgnoreCase(PICKAXES[idx]))
+                    && attackLevel >= ATTACK_REQ[idx]) {
+                Rs2Inventory.interact(PICKAXES[idx], "Wield");
+            }
+            return true;
+        }
+
+        if (!Rs2Bank.isOpen()) {
+            Microbot.status = "Walking to Bank";
+            Rs2Bank.walkToBankAndUseBank();
+            return false;
+        }
+
+        if (currentIndex != -1) {
+            Rs2Bank.depositAll(PICKAXES[currentIndex]);
+        }
+
+        for (int i = 0; i <= bestIndex; i++) {
+            if (Rs2Bank.hasItem(PICKAXES[i])) {
+                Microbot.status = "Withdrawing pickaxe";
+                Rs2Bank.withdrawItem(true, PICKAXES[i]);
+                if (attackLevel >= ATTACK_REQ[i]) {
+                    Rs2Inventory.interact(PICKAXES[i], "Wield");
+                }
+                break;
+            }
+        }
+
+        Rs2Bank.closeBank();
+
+        return Rs2Equipment.isWearing(item -> item.getName().toLowerCase().contains("pickaxe")) ||
+                Rs2Inventory.contains(item -> item.getName().toLowerCase().contains("pickaxe"));
+    }
+
+    private void depositUncutGems() {
+        Rs2Bank.depositAll("Uncut diamond");
+        Rs2Bank.depositAll("Uncut ruby");
+        Rs2Bank.depositAll("Uncut emerald");
+        Rs2Bank.depositAll("Uncut sapphire");
+    }
+
+    public void trainLowLevelMining() {
+        if (!ensurePickaxe()) {
+            Microbot.status = "Getting pickaxe";
+            return;
+        }
+
+        if (Rs2Inventory.isFull()) {
+            Microbot.status = "Banking ore";
+            if (Rs2Bank.walkToBankAndUseBank()) {
+                Rs2Bank.depositAll("tin ore");
+                Rs2Bank.depositAll("copper ore");
+                depositUncutGems();
+                ensurePickaxe();
+                Rs2Bank.closeBank();
+            }
+            return;
+        }
+
+        WorldPoint mine = new WorldPoint(3288, 3363, 0);
+        if (Rs2Player.getWorldLocation().distanceTo(mine) > 5) {
+            Microbot.status = "Walking to mine";
+            Rs2Walker.walkTo(mine);
+            return;
+        }
+        script.startSwitchTimerIfNeeded();
+
+        if (waitingForAnim) {
+            if (Rs2Player.isAnimating()) {
+                waitingForAnim = false;
+                Microbot.status = "Mining";
+            } else if (System.currentTimeMillis() - animWaitStart > 5000) {
+                waitingForAnim = false;
+                Microbot.status = "Idle";
+            } else {
+                return;
+            }
+        }
+
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            Microbot.status = "Mining";
+            return;
+        }
+
+        int tinCount = Rs2Inventory.itemQuantity("tin ore");
+        int copperCount = Rs2Inventory.itemQuantity("copper ore");
+        String rockName = tinCount <= copperCount ? "Tin rocks" : "Copper rocks";
+
+        GameObject rock = Rs2GameObject.findReachableObject(rockName, true, 10,
+                Rs2Player.getWorldLocation());
+        if (rock != null && Rs2GameObject.interact(rock)) {
+            Microbot.status = "Mining";
+            waitingForAnim = true;
+            animWaitStart = System.currentTimeMillis();
+            Rs2Player.waitForXpDrop(Skill.MINING, true);
+            Rs2Antiban.actionCooldown();
+        } else {
+            Microbot.status = "Idle";
+        }
+    }
+
+    @Override
+    public void train() {
+        int miningLevel = Rs2Player.getRealSkillLevel(Skill.MINING);
+        if (miningLevel >= 30) {
+            trainCoalMining();
+        } else if (miningLevel >= 15) {
+            trainIronMining();
+        } else {
+            trainLowLevelMining();
+        }
+    }
+
+    public void trainIronMining() {
+        if (!ensurePickaxe()) {
+            Microbot.status = "Getting pickaxe";
+            return;
+        }
+
+        if (Rs2Inventory.isFull()) {
+            Microbot.status = "Banking ore";
+            if (Rs2DepositBox.walkToAndUseDepositBox()) {
+                Rs2DepositBox.depositAllExcept(Arrays.asList("pickaxe"), false);
+                Rs2DepositBox.closeDepositBox();
+            }
+            ensurePickaxe();
+            return;
+        }
+
+        WorldPoint mine = new WorldPoint(2970, 3239, 0);
+        if (Rs2Player.getWorldLocation().distanceTo(mine) > 5) {
+            Microbot.status = "Walking to mine";
+            Rs2Walker.walkTo(mine);
+            return;
+        }
+        script.startSwitchTimerIfNeeded();
+
+        if (waitingForAnim) {
+            if (Rs2Player.isAnimating()) {
+                waitingForAnim = false;
+                Microbot.status = "Mining";
+            } else if (System.currentTimeMillis() - animWaitStart > 5000) {
+                waitingForAnim = false;
+                Microbot.status = "Idle";
+            } else {
+                return;
+            }
+        }
+
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            Microbot.status = "Mining";
+            return;
+        }
+
+        GameObject rock = Rs2GameObject.findReachableObject("Iron rocks", true, 10,
+                Rs2Player.getWorldLocation());
+        if (rock != null && Rs2GameObject.interact(rock)) {
+            Microbot.status = "Mining";
+            waitingForAnim = true;
+            animWaitStart = System.currentTimeMillis();
+            Rs2Player.waitForXpDrop(Skill.MINING, true);
+            Rs2Antiban.actionCooldown();
+        } else {
+            Microbot.status = "Idle";
+        }
+    }
+
+    public void trainCoalMining() {
+        if (!ensurePickaxe()) {
+            Microbot.status = "Getting pickaxe";
+            return;
+        }
+
+        if (Rs2Inventory.isFull()) {
+            Microbot.status = "Banking ore";
+            if (Rs2Bank.walkToBankAndUseBank()) {
+                Rs2Bank.depositAll("coal");
+                Rs2Bank.depositAll("iron ore");
+                Rs2Bank.depositAll("copper ore");
+                Rs2Bank.depositAll("tin ore");
+                depositUncutGems();
+                ensurePickaxe();
+                Rs2Bank.closeBank();
+            }
+            return;
+        }
+
+        WorldPoint mine = new WorldPoint(3083, 3422, 0);
+        if (Rs2Player.getWorldLocation().distanceTo(mine) > 5) {
+            Microbot.status = "Walking to mine";
+            Rs2Walker.walkTo(mine);
+            return;
+        }
+        script.startSwitchTimerIfNeeded();
+
+        if (waitingForAnim) {
+            if (Rs2Player.isAnimating()) {
+                waitingForAnim = false;
+                Microbot.status = "Mining";
+            } else if (System.currentTimeMillis() - animWaitStart > 5000) {
+                waitingForAnim = false;
+                Microbot.status = "Idle";
+            } else {
+                return;
+            }
+        }
+
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            Microbot.status = "Mining";
+            return;
+        }
+
+        GameObject rock = Rs2GameObject.findReachableObject("Coal rocks", true, 10,
+                Rs2Player.getWorldLocation());
+        if (rock != null && Rs2GameObject.interact(rock)) {
+            Microbot.status = "Mining";
+            waitingForAnim = true;
+            animWaitStart = System.currentTimeMillis();
+            Rs2Player.waitForXpDrop(Skill.MINING, true);
+            Rs2Antiban.actionCooldown();
+        } else {
+            Microbot.status = "Idle";
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerConfig.java
@@ -1,0 +1,88 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+
+@ConfigGroup(RandomTrainerConfig.GROUP)
+public interface RandomTrainerConfig extends Config {
+    String GROUP = "randomtrainer";
+
+    @ConfigSection(
+            name = "General",
+            description = "General settings",
+            position = 0
+    )
+    String generalSection = "general";
+
+    @ConfigItem(
+            keyName = "switchDelay",
+            name = "Skill Switch Delay (min)",
+            description = "Time in minutes between selecting a new skill to train",
+            position = 0,
+            section = generalSection
+    )
+    default int switchDelay() { return 10; }
+
+    @ConfigSection(
+            name = "Combat",
+            description = "Combat Training Goals",
+            position = 1
+    )
+    String combatSection = "combat";
+
+    @ConfigItem(
+            keyName = "attackLevels",
+            name = "Attack Levels",
+            description = "Levels of Attack to train",
+            position = 0,
+            section = combatSection
+    )
+    default int attackLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "strengthLevels",
+            name = "Strength Levels",
+            description = "Levels of Strength to train",
+            position = 1,
+            section = combatSection
+    )
+    default int strengthLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "defenceLevels",
+            name = "Defence Levels",
+            description = "Levels of Defence to train",
+            position = 2,
+            section = combatSection
+    )
+    default int defenceLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "rangedLevels",
+            name = "Ranged Levels",
+            description = "Levels of Ranged to train",
+            position = 3,
+            section = combatSection
+    )
+    default int rangedLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "mageLevels",
+            name = "Mage Levels",
+            description = "Levels of Magic to train",
+            position = 4,
+            section = combatSection
+    )
+    default int mageLevels() { return 0; }
+
+    @ConfigItem(
+            keyName = "healAtHp",
+            name = "Heal at HP",
+            description = "Eat food when HP is at or below this amount",
+            position = 5,
+            section = combatSection
+    )
+    default int healAtHp() { return 0; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerOverlay.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+
+public class RandomTrainerOverlay extends OverlayPanel {
+    private final RandomTrainerScript script;
+
+    @Inject
+    public RandomTrainerOverlay(RandomTrainerScript script) {
+        super();
+        this.script = script;
+        setPosition(OverlayPosition.TOP_LEFT);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.getChildren().clear();
+        panelComponent.setPreferredSize(new Dimension(200, 96));
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("Random Trainer V" + RandomTrainerScript.VERSION)
+                .color(Color.GREEN)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder().build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status: " + Microbot.status)
+                .build());
+        String task = "None";
+        if (script != null) {
+            task = script.getCurrentTaskName();
+        }
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Current Task: " + task)
+                .build());
+        String runtime = script != null ? script.getTimeRunning() : "00:00:00";
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Time Running: " + runtime)
+                .build());
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerPlugin.java
@@ -1,0 +1,53 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import com.google.inject.Provides;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.AWTException;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "Random Trainer",
+        description = "Trains random skills",
+        tags = {"random", "trainer", "microbot"},
+        enabledByDefault = false
+)
+public class RandomTrainerPlugin extends Plugin {
+    static final String VERSION = RandomTrainerScript.VERSION;
+
+    @Inject
+    private RandomTrainerConfig config;
+
+    @Provides
+    RandomTrainerConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(RandomTrainerConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private RandomTrainerOverlay overlay;
+    @Inject
+    private RandomTrainerScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (script.run(config, this)) {
+            overlayManager.add(overlay);
+        }
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+
+    public boolean isBreakHandlerEnabled() {
+        return net.runelite.client.plugins.microbot.Microbot.isPluginEnabled(net.runelite.client.plugins.microbot.breakhandler.BreakHandlerPlugin.class);
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/RandomTrainerScript.java
@@ -1,0 +1,177 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.api.Skill;
+import java.util.Map;
+import java.util.HashMap;
+// Trainers implementing the generic SkillTrainer interface
+// are mapped to their corresponding tasks within this script.
+import net.runelite.client.plugins.microbot.randomtrainer.MiningTrainer;
+import net.runelite.client.plugins.microbot.randomtrainer.WoodcuttingTrainer;
+import net.runelite.client.plugins.microbot.randomtrainer.FishingTrainer;
+import net.runelite.client.plugins.microbot.randomtrainer.SkillTrainer;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class RandomTrainerScript extends Script {
+    public static final String VERSION = "1.0.0";
+
+    private RandomTrainerConfig config;
+    private RandomTrainerPlugin plugin;
+    private SkillTask currentTask;
+    private long nextSwitch;
+    private boolean switchTimerStarted;
+    private final Random random = new Random();
+    private boolean idleForBreak = false;
+
+    private MiningTrainer miningTrainer;
+    private WoodcuttingTrainer woodcuttingTrainer;
+    private FishingTrainer fishingTrainer;
+    private final Map<SkillTask, SkillTrainer> trainers = new HashMap<>();
+
+    public boolean run(RandomTrainerConfig config, RandomTrainerPlugin plugin) {
+        if (isRunning() || !Microbot.isLoggedIn()) {
+            return false;
+        }
+
+        this.config = config;
+        this.plugin = plugin;
+
+        miningTrainer = new MiningTrainer(this);
+        woodcuttingTrainer = new WoodcuttingTrainer(this);
+        fishingTrainer = new FishingTrainer(this);
+
+        trainers.clear();
+        trainers.put(SkillTask.MINING, miningTrainer);
+        trainers.put(SkillTask.WOODCUTTING, woodcuttingTrainer);
+        trainers.put(SkillTask.FISHING, fishingTrainer);
+
+        Rs2Antiban.resetAntibanSettings();
+        Rs2AntibanSettings.naturalMouse = true;
+        Rs2AntibanSettings.contextualVariability = true;
+        Rs2AntibanSettings.dynamicActivity = true;
+        Rs2AntibanSettings.behavioralVariability = true;
+        Rs2AntibanSettings.actionCooldownChance = 0.1;
+
+        nextSwitch = Long.MAX_VALUE;
+        switchTimerStarted = false;
+        Microbot.status = "Selecting task";
+        selectNewTask();
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(this::loop, 0, 1, TimeUnit.SECONDS);
+        return true;
+    }
+
+    public SkillTask getCurrentTask() {
+        return currentTask;
+    }
+
+    public String getCurrentTaskName() {
+        if (currentTask == null) {
+            return "None";
+        }
+        String n = currentTask.name().toLowerCase();
+        return Character.toUpperCase(n.charAt(0)) + n.substring(1);
+    }
+
+    public String getTimeRunning() {
+        return DurationFormatUtils.formatDuration(getRunTime().toMillis(), "HH:mm:ss", true);
+    }
+
+    public void startSwitchTimerIfNeeded() {
+        if (!switchTimerStarted) {
+            nextSwitch = System.currentTimeMillis() + config.switchDelay() * 60_000L;
+            switchTimerStarted = true;
+        }
+    }
+
+    private void loop() {
+        try {
+            if (!super.run() || !Microbot.isLoggedIn()) return;
+
+            if (shouldIdleForBreak()) {
+                handleUpcomingBreak();
+                return;
+            } else if (idleForBreak) {
+                idleForBreak = false;
+            }
+
+            if (config.healAtHp() > 0) {
+                int hp = Microbot.getClient().getBoostedSkillLevel(Skill.HITPOINTS);
+                if (hp <= config.healAtHp()) {
+                    Rs2Player.useFood();
+                }
+            }
+
+            if (System.currentTimeMillis() >= nextSwitch) {
+                selectNewTask();
+            }
+
+            executeCurrentTask();
+        } catch (Exception ex) {
+            Microbot.log(ex.getMessage());
+        }
+    }
+
+    private boolean shouldIdleForBreak() {
+        return plugin.isBreakHandlerEnabled() && BreakHandlerScript.breakIn > 0 && BreakHandlerScript.breakIn <= 180;
+    }
+
+    private void handleUpcomingBreak() {
+        Microbot.status = "Break soon, idling at bank";
+        if (!idleForBreak) {
+            if (Rs2Bank.walkToBankAndUseBank()) {
+                Rs2Bank.depositAll();
+                Rs2Bank.closeBank();
+            }
+            idleForBreak = true;
+        }
+        sleep(1000);
+    }
+
+    private void bankInventory() {
+        Microbot.status = "Walking to Bank";
+        if (!Rs2Bank.isOpen()) {
+            if (!Rs2Bank.walkToBankAndUseBank()) {
+                return;
+            }
+        }
+        Rs2Bank.depositAll();
+        Rs2Bank.closeBank();
+    }
+
+    private void selectNewTask() {
+        bankInventory();
+
+        SkillTask[] available = trainers.keySet().toArray(new SkillTask[0]);
+        SkillTask newTask;
+        do {
+            newTask = available[random.nextInt(available.length)];
+        } while (newTask == currentTask);
+        currentTask = newTask;
+        switchTimerStarted = false;
+        nextSwitch = Long.MAX_VALUE;
+        Microbot.status = "Idle";
+    }
+
+    private void executeCurrentTask() {
+        SkillTrainer trainer = trainers.get(currentTask);
+        if (trainer != null) {
+            trainer.train();
+        } else {
+            Microbot.status = "Idle";
+        }
+    }
+
+    // Reserved for future plugin integrations
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/SkillTask.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/SkillTask.java
@@ -1,0 +1,14 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+public enum SkillTask {
+    MINING,
+    SMITHING,
+    CRAFTING,
+    WOODCUTTING,
+    RUNECRAFTING,
+    FIREMAKING,
+    FISHING,
+    COOKING,
+    RANGED,
+    PRAYER;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/SkillTrainer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/SkillTrainer.java
@@ -1,0 +1,5 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+public interface SkillTrainer {
+    void train();
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/WoodcuttingTrainer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/randomtrainer/WoodcuttingTrainer.java
@@ -1,0 +1,282 @@
+package net.runelite.client.plugins.microbot.randomtrainer;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.depositbox.Rs2DepositBox;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.GameObject;
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.microbot.randomtrainer.RandomTrainerScript;
+
+public class WoodcuttingTrainer implements SkillTrainer {
+    private final RandomTrainerScript script;
+    private static final String[] AXES = {
+            "Rune axe",
+            "Adamant axe",
+            "Mithril axe",
+            "Black axe",
+            "Steel axe",
+            "Iron axe",
+            "Bronze axe"
+    };
+
+    private static final int[] WOODCUTTING_REQ = {41, 31, 21, 11, 6, 1, 1};
+    private static final int[] AXE_ATTACK_REQ = {40, 30, 20, 10, 5, 1, 1};
+
+    private boolean waitingForAnim = false;
+    private long animWaitStart = 0L;
+
+    public WoodcuttingTrainer(RandomTrainerScript script) {
+        this.script = script;
+    }
+
+    private boolean ensureAxe() {
+        int wcLevel = Rs2Player.getRealSkillLevel(Skill.WOODCUTTING);
+        int attackLevel = Rs2Player.getRealSkillLevel(Skill.ATTACK);
+
+        int bestIndex = AXES.length - 1;
+        for (int i = 0; i < AXES.length; i++) {
+            if (wcLevel >= WOODCUTTING_REQ[i]) {
+                bestIndex = i;
+                break;
+            }
+        }
+
+        int currentIndex = -1;
+        for (int i = 0; i < AXES.length; i++) {
+            String name = AXES[i];
+            if (Rs2Equipment.isWearing(eq -> eq.getName().equalsIgnoreCase(name)) || Rs2Inventory.hasItem(name)) {
+                currentIndex = i;
+                break;
+            }
+        }
+
+        if (currentIndex != -1 && currentIndex <= bestIndex) {
+            if (!Rs2Equipment.isWearing(eq -> eq.getName().equalsIgnoreCase(AXES[currentIndex]))
+                    && attackLevel >= AXE_ATTACK_REQ[currentIndex]) {
+                Rs2Inventory.interact(AXES[currentIndex], "Wield");
+            }
+            return true;
+        }
+
+        if (!Rs2Bank.isOpen()) {
+            Microbot.status = "Walking to Bank";
+            Rs2Bank.walkToBankAndUseBank();
+            return false;
+        }
+
+        if (currentIndex != -1) {
+            Rs2Bank.depositAll(AXES[currentIndex]);
+        }
+
+        for (int i = 0; i <= bestIndex; i++) {
+            if (Rs2Bank.hasItem(AXES[i])) {
+                Microbot.status = "Withdrawing axe";
+                Rs2Bank.withdrawItem(true, AXES[i]);
+                if (attackLevel >= AXE_ATTACK_REQ[i]) {
+                    Rs2Inventory.interact(AXES[i], "Wield");
+                }
+                break;
+            }
+        }
+
+        Rs2Bank.closeBank();
+
+        return Rs2Equipment.isWearing(item -> item.getName().toLowerCase().contains("axe")) ||
+                Rs2Inventory.contains(item -> item.getName().toLowerCase().contains("axe"));
+    }
+
+    public void trainLowLevelWoodcutting() {
+        if (!ensureAxe()) {
+            Microbot.status = "Getting axe";
+            return;
+        }
+
+        if (Rs2Inventory.isFull()) {
+            Microbot.status = "Banking logs";
+            if (Rs2Bank.walkToBankAndUseBank()) {
+                Rs2Bank.depositAll();
+                ensureAxe();
+                Rs2Bank.closeBank();
+            }
+            return;
+        }
+
+        WorldPoint defaultTrees = new WorldPoint(3162, 3454, 0);
+        WorldPoint altTrees = new WorldPoint(3276, 3444, 0);
+
+        long playerCount = Rs2Player.getPlayers(p ->
+                p.getWorldLocation().distanceTo(defaultTrees) <= 5).count();
+        WorldPoint trees = playerCount > 3 ? altTrees : defaultTrees;
+
+        if (Rs2Player.getWorldLocation().distanceTo(trees) > 5) {
+            Microbot.status = "Walking to trees";
+            Rs2Walker.walkTo(trees);
+            return;
+        }
+        script.startSwitchTimerIfNeeded();
+
+        if (waitingForAnim) {
+            if (Rs2Player.isAnimating()) {
+                waitingForAnim = false;
+                Microbot.status = "Woodcutting";
+            } else if (System.currentTimeMillis() - animWaitStart > 5000) {
+                waitingForAnim = false;
+                Microbot.status = "Idle";
+            } else {
+                return;
+            }
+        }
+
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            Microbot.status = "Woodcutting";
+            return;
+        }
+
+        GameObject tree = Rs2GameObject.findReachableObject("Tree", true, 10,
+                Rs2Player.getWorldLocation(), true, "Chop down");
+        if (tree != null && Rs2GameObject.interact(tree)) {
+            Microbot.status = "Woodcutting";
+            waitingForAnim = true;
+            animWaitStart = System.currentTimeMillis();
+            Rs2Player.waitForXpDrop(Skill.WOODCUTTING, true);
+            Rs2Antiban.actionCooldown();
+        } else {
+            Microbot.status = "Idle";
+        }
+    }
+
+    public void trainOakWoodcutting() {
+        if (!ensureAxe()) {
+            Microbot.status = "Getting axe";
+            return;
+        }
+
+        if (Rs2Inventory.isFull()) {
+            Microbot.status = "Banking logs";
+            if (Rs2Bank.walkToBankAndUseBank()) {
+                Rs2Bank.depositAll();
+                ensureAxe();
+                Rs2Bank.closeBank();
+            }
+            return;
+        }
+
+        WorldPoint oaks = new WorldPoint(3192, 3461, 0);
+        if (Rs2Player.getWorldLocation().distanceTo(oaks) > 5) {
+            Microbot.status = "Walking to trees";
+            Rs2Walker.walkTo(oaks);
+            return;
+        }
+        script.startSwitchTimerIfNeeded();
+
+        if (waitingForAnim) {
+            if (Rs2Player.isAnimating()) {
+                waitingForAnim = false;
+                Microbot.status = "Woodcutting";
+            } else if (System.currentTimeMillis() - animWaitStart > 5000) {
+                waitingForAnim = false;
+                Microbot.status = "Idle";
+            } else {
+                return;
+            }
+        }
+
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            Microbot.status = "Woodcutting";
+            return;
+        }
+
+        GameObject tree = Rs2GameObject.findReachableObject("Oak", true, 10,
+                Rs2Player.getWorldLocation(), true, "Chop down");
+        if (tree != null && Rs2GameObject.interact(tree)) {
+            Microbot.status = "Woodcutting";
+            waitingForAnim = true;
+            animWaitStart = System.currentTimeMillis();
+            Rs2Player.waitForXpDrop(Skill.WOODCUTTING, true);
+            Rs2Antiban.actionCooldown();
+        } else {
+            Microbot.status = "Idle";
+        }
+    }
+
+    public void trainWillowWoodcutting() {
+        if (!ensureAxe()) {
+            Microbot.status = "Getting axe";
+            return;
+        }
+
+        if (Rs2Inventory.isFull()) {
+            Microbot.status = "Banking logs";
+            WorldPoint deposit = new WorldPoint(3046, 3235, 0);
+            if (Rs2Player.getWorldLocation().distanceTo(deposit) > 5) {
+                Rs2Walker.walkTo(deposit);
+                return;
+            }
+            if (!Rs2DepositBox.isOpen()) {
+                if (!Rs2DepositBox.openDepositBox()) {
+                    return;
+                }
+            }
+            Rs2DepositBox.depositAll("Willow logs");
+            Rs2DepositBox.closeDepositBox();
+            ensureAxe();
+            return;
+        }
+
+        WorldPoint willows = new WorldPoint(3060, 3254, 0);
+        if (Rs2Player.getWorldLocation().distanceTo(willows) > 5) {
+            Microbot.status = "Walking to trees";
+            Rs2Walker.walkTo(willows);
+            return;
+        }
+        script.startSwitchTimerIfNeeded();
+
+        if (waitingForAnim) {
+            if (Rs2Player.isAnimating()) {
+                waitingForAnim = false;
+                Microbot.status = "Woodcutting";
+            } else if (System.currentTimeMillis() - animWaitStart > 5000) {
+                waitingForAnim = false;
+                Microbot.status = "Idle";
+            } else {
+                return;
+            }
+        }
+
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            Microbot.status = "Woodcutting";
+            return;
+        }
+
+        GameObject tree = Rs2GameObject.findReachableObject("Willow", true, 10,
+                Rs2Player.getWorldLocation(), true, "Chop down");
+        if (tree != null && Rs2GameObject.interact(tree)) {
+            Microbot.status = "Woodcutting";
+            waitingForAnim = true;
+            animWaitStart = System.currentTimeMillis();
+            Rs2Player.waitForXpDrop(Skill.WOODCUTTING, true);
+            Rs2Antiban.actionCooldown();
+        } else {
+            Microbot.status = "Idle";
+        }
+    }
+
+    @Override
+    public void train() {
+        int wcLevel = Rs2Player.getRealSkillLevel(Skill.WOODCUTTING);
+        if (wcLevel < 15) {
+            trainLowLevelWoodcutting();
+        } else if (wcLevel < 30) {
+            trainOakWoodcutting();
+        } else if (wcLevel < 60) {
+            trainWillowWoodcutting();
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/depositbox/DepositBoxLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/depositbox/DepositBoxLocation.java
@@ -21,7 +21,9 @@ public enum DepositBoxLocation {
     GEM_MINE(new WorldPoint(2842, 9383, 0)),
     GRAND_EXCHANGE(new WorldPoint(3174, 3493, 0)),
     LUMBRIDGE(new WorldPoint(3210, 3217, 2)),
-    PORT_SARIM(new WorldPoint(3045, 3234, 0)),
+    // Updated to the tile directly beside the deposit box so the player can
+    // easily interact with it when banking ores or logs.
+    PORT_SARIM(new WorldPoint(3045, 3236, 0)),
     VARROCK(new WorldPoint(3180, 3433, 0)),
     ALDARIN(new WorldPoint(1395, 2925, 0)),
     ARCEUUS(new WorldPoint(1626, 3737, 0)),


### PR DESCRIPTION
## Summary
- improve pickaxe and axe selection by withdrawing the best available tool
- swap to better tools when banking ores or logs before returning to training
- ensure deposit-box banking still upgrades tools via the nearest bank
- add fishing trainer that nets shrimp until level 20 and then fly fishes with rod and feathers
- fix fishing gear text to match the exact item name
- fix missing closing brace in `RandomTrainerPlugin`
- fix compilation issues in trainers

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686580a0194083308c93dedcc767e3c5