### PR TITLE
Add PluginConstants and autofishing enums (Fish, FishingMethod)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/PluginConstants.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/PluginConstants.java
@@ -1,0 +1,11 @@
+package net.runelite.client.plugins.microbot;
+
+public final class PluginConstants {
+	public static final String MICROBOT_GROUP = "microbot";
+	public static final String MICROBOT_TAG = "microbot";
+	public static final String MICROBOT_PLUGIN_NAME_PREFIX = "Microbot";
+	public static final String MICROBOT_PLUGIN_PACKAGE = "net.runelite.client.plugins.microbot";
+
+	private PluginConstants() {
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autofishing/enums/Fish.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autofishing/enums/Fish.java
@@ -1,0 +1,37 @@
+package net.runelite.client.plugins.microbot.autofishing.enums;
+
+import net.runelite.api.ItemID;
+
+public enum Fish {
+	SHRIMP("Shrimp", ItemID.RAW_SHRIMPS, ItemID.SHRIMPS),
+	ANCHOVIES("Anchovies", ItemID.RAW_ANCHOVIES, ItemID.ANCHOVIES),
+	SARDINE("Sardine", ItemID.RAW_SARDINE, ItemID.SARDINE),
+	HERRING("Herring", ItemID.RAW_HERRING, ItemID.HERRING),
+	TROUT("Trout", ItemID.RAW_TROUT, ItemID.TROUT),
+	SALMON("Salmon", ItemID.RAW_SALMON, ItemID.SALMON),
+	TUNA("Tuna", ItemID.RAW_TUNA, ItemID.TUNA),
+	LOBSTER("Lobster", ItemID.RAW_LOBSTER, ItemID.LOBSTER),
+	SWORDFISH("Swordfish", ItemID.RAW_SWORDFISH, ItemID.SWORDFISH);
+
+	private final String name;
+	private final int rawItemId;
+	private final int cookedItemId;
+
+	Fish(String name, int rawItemId, int cookedItemId) {
+		this.name = name;
+		this.rawItemId = rawItemId;
+		this.cookedItemId = cookedItemId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getRawItemId() {
+		return rawItemId;
+	}
+
+	public int getCookedItemId() {
+		return cookedItemId;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autofishing/enums/FishingMethod.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autofishing/enums/FishingMethod.java
@@ -1,0 +1,21 @@
+package net.runelite.client.plugins.microbot.autofishing.enums;
+
+public enum FishingMethod {
+	SMALL_NET("Small net"),
+	BIG_NET("Big net"),
+	NET("Net"),
+	BAIT("Bait"),
+	LURE("Lure"),
+	CAGE("Cage"),
+	HARPOON("Harpoon");
+
+	private final String displayName;
+
+	FishingMethod(String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide the missing `Fish` and `FishingMethod` enums required by the autofishing plugin to satisfy compile-time references.
- Fix a compile error caused by a missing `PluginConstants` type referenced by microbot plugin code.

### Description
- Add `runelite-client/src/main/java/net/runelite/client/plugins/microbot/PluginConstants.java` containing shared microbot plugin identifiers `MICROBOT_GROUP`, `MICROBOT_TAG`, `MICROBOT_PLUGIN_NAME_PREFIX`, and `MICROBOT_PLUGIN_PACKAGE`.
- Add `runelite-client/src/main/java/net/runelite/client/plugins/microbot/autofishing/enums/Fish.java` which defines a `Fish` enum with `name`, `rawItemId`, and `cookedItemId` entries for common F2P fish using `net.runelite.api.ItemID`.
- Add `runelite-client/src/main/java/net/runelite/client/plugins/microbot/autofishing/enums/FishingMethod.java` which defines a `FishingMethod` enum with common fishing interaction display names and a `getDisplayName()` accessor.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698782858f7883309e1ca64ac9215c02)